### PR TITLE
Improve HUD layout and cooldown tracking

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -46,16 +46,22 @@ function HUDController:CreateInterface(playerGui: PlayerGui)
     local font = uiConfig.Font or Enum.Font.Gotham
     local boldFont = uiConfig.BoldFont or Enum.Font.GothamBold
     local safeMargin = uiConfig.SafeMargin or 24
-    local topBarHeight = uiConfig.TopBarHeight or 48
-    local topBarBackground = uiConfig.TopBarBackgroundColor or Color3.fromRGB(18, 24, 32)
-    local topLabelSize = uiConfig.TopLabelTextSize or 18
     local infoTextSize = uiConfig.InfoTextSize or 18
     local smallTextSize = uiConfig.SmallTextSize or 16
     local alertTextSize = uiConfig.AlertTextSize or 20
+    local sidePanelWidth = uiConfig.SidePanelWidth or uiConfig.TopInfoWidth or 260
+    local sectionSpacing = uiConfig.SectionSpacing or 12
+    local panelBackground = uiConfig.PanelBackgroundColor or uiConfig.TopBarBackgroundColor or Color3.fromRGB(18, 24, 32)
+    local panelTransparency = uiConfig.PanelBackgroundTransparency or uiConfig.TopBarTransparency or 0.35
+    local panelCornerRadius = uiConfig.PanelCornerRadius or 12
+    local panelStrokeColor = uiConfig.PanelStrokeColor or Color3.fromRGB(80, 120, 160)
+    local panelStrokeThickness = uiConfig.PanelStrokeThickness or 1.5
+    local panelStrokeTransparency = uiConfig.PanelStrokeTransparency or 0.45
+    local panelPadding = uiConfig.PanelPadding or 12
 
     local screen = Instance.new("ScreenGui")
     screen.Name = "SkillSurvivalHUD"
-    screen.IgnoreGuiInset = true
+    screen.IgnoreGuiInset = false
     screen.ResetOnSpawn = false
     screen.DisplayOrder = (uiConfig.DisplayOrder and uiConfig.DisplayOrder.HUD) or 0
     screen.Parent = playerGui
@@ -67,145 +73,166 @@ function HUDController:CreateInterface(playerGui: PlayerGui)
     safeFrame.Position = UDim2.new(0, safeMargin, 0, safeMargin)
     safeFrame.Parent = screen
 
-    local topBar = Instance.new("Frame")
-    topBar.Name = "TopBar"
-    topBar.BackgroundColor3 = topBarBackground
-    topBar.BackgroundTransparency = uiConfig.TopBarTransparency or 0.35
-    topBar.BorderSizePixel = 0
-    topBar.Size = UDim2.new(1, 0, 0, topBarHeight)
-    topBar.Parent = safeFrame
-
-    local waveLabel = createTextLabel(topBar, "Wave 0", boldFont, topLabelSize, Enum.TextXAlignment.Left)
-    waveLabel.Size = UDim2.new(0, 220, 1, 0)
-    waveLabel.Position = UDim2.new(0, 16, 0, 0)
-
-    local enemyLabel = createTextLabel(topBar, "Enemies: 0", boldFont, topLabelSize, Enum.TextXAlignment.Center)
-    enemyLabel.AnchorPoint = Vector2.new(0.5, 0)
-    enemyLabel.Position = UDim2.new(0.5, 0, 0, 0)
-    enemyLabel.Size = UDim2.new(0, 260, 1, 0)
-
-    local timerLabel = createTextLabel(topBar, "Time: ∞", boldFont, topLabelSize, Enum.TextXAlignment.Right)
-    timerLabel.AnchorPoint = Vector2.new(1, 0)
-    timerLabel.Position = UDim2.new(1, -16, 0, 0)
-    timerLabel.Size = UDim2.new(0, 220, 1, 0)
-
-    local resourceFrame = Instance.new("Frame")
-    resourceFrame.Name = "ResourceFrame"
-    resourceFrame.BackgroundTransparency = 1
-    resourceFrame.Size = UDim2.new(0, uiConfig.TopInfoWidth or 240, 0, 0)
-    resourceFrame.AutomaticSize = Enum.AutomaticSize.Y
-    resourceFrame.Position = UDim2.new(0, 0, 0, topBarHeight + (uiConfig.SectionSpacing or 12))
-    resourceFrame.Parent = safeFrame
-
-    local resourceLayout = Instance.new("UIListLayout")
-    resourceLayout.FillDirection = Enum.FillDirection.Vertical
-    resourceLayout.SortOrder = Enum.SortOrder.LayoutOrder
-    resourceLayout.VerticalAlignment = Enum.VerticalAlignment.Top
-    resourceLayout.Padding = UDim.new(0, 6)
-    resourceLayout.Parent = resourceFrame
-
-    local goldLabel = createTextLabel(resourceFrame, "Gold: 0", font, infoTextSize, Enum.TextXAlignment.Left)
-    goldLabel.LayoutOrder = 1
-
     local abilityConfig = uiConfig.Abilities or {}
-    local dashSize = (uiConfig.Dash and uiConfig.Dash.Size) or 72
+    local dashConfig = uiConfig.Dash or {}
+    local dashSize = dashConfig.Size or 72
     local abilityWidth = abilityConfig.Width or 260
     local abilityHeight = abilityConfig.Height or 90
     local abilitySpacing = abilityConfig.Spacing or 12
     local abilitySkillWidth = abilityConfig.SkillWidth or 150
     local abilitySkillHeight = abilityConfig.SkillHeight or 36
+    local abilityBottomOffset = abilityConfig.BottomOffset or 0
 
     abilityWidth = math.max(abilityWidth, abilitySkillWidth + abilitySpacing + dashSize)
     abilityHeight = math.max(abilityHeight, dashSize)
-    local skillY = math.max(0, math.floor((abilityHeight - abilitySkillHeight) / 2))
-    local dashY = math.max(0, math.floor((abilityHeight - dashSize) / 2))
 
-    local abilityFrame = Instance.new("Frame")
-    abilityFrame.Name = "AbilityFrame"
-    abilityFrame.BackgroundTransparency = 1
-    abilityFrame.AnchorPoint = Vector2.new(0, 1)
-    abilityFrame.Position = UDim2.new(0, 0, 1, 0)
-    abilityFrame.Size = UDim2.new(0, abilityWidth, 0, abilityHeight)
-    abilityFrame.Parent = safeFrame
+    local reservedBottom = math.max(0, abilityHeight + abilityBottomOffset + sectionSpacing)
 
-    local skillLabel = createTextLabel(abilityFrame, "Q: Ready", boldFont, infoTextSize, Enum.TextXAlignment.Left)
-    skillLabel.Size = UDim2.new(0, abilitySkillWidth, 0, abilitySkillHeight)
-    skillLabel.Position = UDim2.new(0, 0, 0, skillY)
-    skillLabel.TextScaled = true
+    local leftColumn = Instance.new("Frame")
+    leftColumn.Name = "LeftColumn"
+    leftColumn.BackgroundTransparency = 1
+    leftColumn.Size = UDim2.new(0, sidePanelWidth, 1, -reservedBottom)
+    leftColumn.Parent = safeFrame
 
-    local dashContainer = Instance.new("Frame")
-    dashContainer.Name = "DashContainer"
-    dashContainer.BackgroundTransparency = 1
-    dashContainer.Size = UDim2.new(0, dashSize, 0, dashSize)
-    dashContainer.Position = UDim2.new(0, abilitySkillWidth + abilitySpacing, 0, dashY)
-    dashContainer.Parent = abilityFrame
+    local leftLayout = Instance.new("UIListLayout")
+    leftLayout.FillDirection = Enum.FillDirection.Vertical
+    leftLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    leftLayout.Padding = UDim.new(0, sectionSpacing)
+    leftLayout.Parent = leftColumn
 
-    local dashSlot = Instance.new("Frame")
-    dashSlot.Name = "DashSlot"
-    dashSlot.BackgroundTransparency = 1
-    dashSlot.Size = UDim2.fromScale(1, 1)
-    dashSlot.Parent = dashContainer
+    local statusPanel = Instance.new("Frame")
+    statusPanel.Name = "StatusPanel"
+    statusPanel.BackgroundColor3 = panelBackground
+    statusPanel.BackgroundTransparency = panelTransparency
+    statusPanel.BorderSizePixel = 0
+    statusPanel.Size = UDim2.new(1, 0, 0, 0)
+    statusPanel.AutomaticSize = Enum.AutomaticSize.Y
+    statusPanel.Parent = leftColumn
 
-    local dashGauge = Instance.new("Frame")
-    dashGauge.Name = "Gauge"
-    dashGauge.Size = UDim2.fromScale(1, 1)
-    dashGauge.BackgroundColor3 = uiConfig.Dash and uiConfig.Dash.BackgroundColor or Color3.fromRGB(18, 24, 32)
-    dashGauge.BackgroundTransparency = uiConfig.Dash and uiConfig.Dash.BackgroundTransparency or 0.25
-    dashGauge.BorderSizePixel = 0
-    dashGauge.Parent = dashSlot
+    local statusCorner = Instance.new("UICorner")
+    statusCorner.CornerRadius = UDim.new(0, panelCornerRadius)
+    statusCorner.Parent = statusPanel
 
-    local dashCorner = Instance.new("UICorner")
-    dashCorner.CornerRadius = UDim.new(1, 0)
-    dashCorner.Parent = dashGauge
+    local statusStroke = Instance.new("UIStroke")
+    statusStroke.Color = panelStrokeColor
+    statusStroke.Thickness = panelStrokeThickness
+    statusStroke.Transparency = panelStrokeTransparency
+    statusStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+    statusStroke.Parent = statusPanel
 
-    local dashStroke = Instance.new("UIStroke")
-    dashStroke.Thickness = uiConfig.Dash and uiConfig.Dash.StrokeThickness or 2
-    dashStroke.Color = uiConfig.Dash and uiConfig.Dash.StrokeColor or Color3.fromRGB(120, 200, 255)
-    dashStroke.Transparency = uiConfig.Dash and uiConfig.Dash.StrokeTransparency or 0.2
-    dashStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
-    dashStroke.Parent = dashGauge
+    local statusPadding = Instance.new("UIPadding")
+    statusPadding.PaddingTop = UDim.new(0, panelPadding)
+    statusPadding.PaddingBottom = UDim.new(0, panelPadding)
+    statusPadding.PaddingLeft = UDim.new(0, panelPadding)
+    statusPadding.PaddingRight = UDim.new(0, panelPadding)
+    statusPadding.Parent = statusPanel
 
-    local dashMask = Instance.new("Frame")
-    dashMask.Name = "Mask"
-    dashMask.BackgroundTransparency = 1
-    dashMask.Size = UDim2.fromScale(1, 1)
-    dashMask.ClipsDescendants = true
-    dashMask.Parent = dashGauge
+    local statusLayout = Instance.new("UIListLayout")
+    statusLayout.FillDirection = Enum.FillDirection.Vertical
+    statusLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    statusLayout.VerticalAlignment = Enum.VerticalAlignment.Top
+    statusLayout.Padding = UDim.new(0, 6)
+    statusLayout.Parent = statusPanel
 
-    local dashMaskCorner = Instance.new("UICorner")
-    dashMaskCorner.CornerRadius = UDim.new(1, 0)
-    dashMaskCorner.Parent = dashMask
+    local waveLabel = createTextLabel(statusPanel, "Wave 0", boldFont, uiConfig.TopLabelTextSize or 20, Enum.TextXAlignment.Left)
+    waveLabel.LayoutOrder = 1
+    waveLabel.Size = UDim2.new(1, 0, 0, (uiConfig.TopLabelTextSize or 20) + 6)
 
-    local dashFill = Instance.new("Frame")
-    dashFill.Name = "Fill"
-    dashFill.BorderSizePixel = 0
-    dashFill.BackgroundColor3 = uiConfig.Dash and uiConfig.Dash.FillColor or Color3.fromRGB(120, 200, 255)
-    dashFill.BackgroundTransparency = uiConfig.Dash and uiConfig.Dash.FillTransparency or 0.15
-    dashFill.AnchorPoint = Vector2.new(0, 1)
-    dashFill.Position = UDim2.new(0, 0, 1, 0)
-    dashFill.Size = UDim2.new(1, 0, 0, 0)
-    dashFill.Parent = dashMask
+    local enemyLabel = createTextLabel(statusPanel, "Enemies: 0", font, infoTextSize, Enum.TextXAlignment.Left)
+    enemyLabel.LayoutOrder = 2
+    enemyLabel.Size = UDim2.new(1, 0, 0, infoTextSize + 6)
 
-    local dashFillCorner = Instance.new("UICorner")
-    dashFillCorner.CornerRadius = UDim.new(1, 0)
-    dashFillCorner.Parent = dashFill
+    local timerLabel = createTextLabel(statusPanel, "Time: ∞", font, infoTextSize, Enum.TextXAlignment.Left)
+    timerLabel.LayoutOrder = 3
+    timerLabel.Size = UDim2.new(1, 0, 0, infoTextSize + 6)
 
-    local dashKeyLabel = createTextLabel(dashGauge, "E", boldFont, smallTextSize, Enum.TextXAlignment.Center)
-    dashKeyLabel.AnchorPoint = Vector2.new(0.5, 0.5)
-    dashKeyLabel.Position = UDim2.new(0.5, 0, 0.3, 0)
-    dashKeyLabel.TextScaled = true
+    local goldLabel = createTextLabel(statusPanel, "Gold: 0", font, infoTextSize, Enum.TextXAlignment.Left)
+    goldLabel.LayoutOrder = 4
+    goldLabel.Size = UDim2.new(1, 0, 0, infoTextSize + 6)
 
-    local dashCooldownLabel = createTextLabel(dashGauge, "Ready", boldFont, smallTextSize, Enum.TextXAlignment.Center)
-    dashCooldownLabel.AnchorPoint = Vector2.new(0.5, 0.5)
-    dashCooldownLabel.Position = UDim2.new(0.5, 0, 0.72, 0)
-    dashCooldownLabel.TextScaled = true
+    local xpConfig = uiConfig.XP or {}
+
+    local xpPanel = Instance.new("Frame")
+    xpPanel.Name = "XPPanel"
+    xpPanel.BackgroundColor3 = panelBackground
+    xpPanel.BackgroundTransparency = panelTransparency
+    xpPanel.BorderSizePixel = 0
+    xpPanel.Size = UDim2.new(1, 0, 0, 0)
+    xpPanel.AutomaticSize = Enum.AutomaticSize.Y
+    xpPanel.Parent = leftColumn
+
+    local xpCorner = Instance.new("UICorner")
+    xpCorner.CornerRadius = UDim.new(0, panelCornerRadius)
+    xpCorner.Parent = xpPanel
+
+    local xpStroke = Instance.new("UIStroke")
+    xpStroke.Color = panelStrokeColor
+    xpStroke.Thickness = panelStrokeThickness
+    xpStroke.Transparency = panelStrokeTransparency
+    xpStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+    xpStroke.Parent = xpPanel
+
+    local xpPadding = Instance.new("UIPadding")
+    xpPadding.PaddingTop = UDim.new(0, panelPadding)
+    xpPadding.PaddingBottom = UDim.new(0, panelPadding)
+    xpPadding.PaddingLeft = UDim.new(0, panelPadding)
+    xpPadding.PaddingRight = UDim.new(0, panelPadding)
+    xpPadding.Parent = xpPanel
+
+    local xpLayout = Instance.new("UIListLayout")
+    xpLayout.FillDirection = Enum.FillDirection.Vertical
+    xpLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    xpLayout.VerticalAlignment = Enum.VerticalAlignment.Top
+    xpLayout.Padding = UDim.new(0, 6)
+    xpLayout.Parent = xpPanel
+
+    local xpHeader = Instance.new("Frame")
+    xpHeader.Name = "XPHeader"
+    xpHeader.BackgroundTransparency = 1
+    xpHeader.Size = UDim2.new(1, 0, 0, xpConfig.LabelHeight or 24)
+    xpHeader.LayoutOrder = 1
+    xpHeader.Parent = xpPanel
+
+    local levelWidth = xpConfig.LevelWidth or 54
+    local levelSpacing = xpConfig.LevelSpacing or 10
+    local xpLabel = createTextLabel(xpHeader, (xpConfig.LabelPrefix or "XP") .. " 0", font, xpConfig.LabelTextSize or infoTextSize, Enum.TextXAlignment.Left)
+    xpLabel.Size = UDim2.new(1, -(levelWidth + levelSpacing), 1, 0)
+
+    local levelLabel = createTextLabel(xpHeader, "Lv 1", boldFont, xpConfig.LevelTextSize or alertTextSize, Enum.TextXAlignment.Right)
+    levelLabel.AnchorPoint = Vector2.new(1, 0.5)
+    levelLabel.Position = UDim2.new(1, 0, 0.5, 0)
+    levelLabel.Size = UDim2.new(0, levelWidth, 1, 0)
+
+    local xpBar = Instance.new("Frame")
+    xpBar.Name = "XPBar"
+    xpBar.BackgroundColor3 = xpConfig.BackgroundColor or Color3.fromRGB(18, 24, 32)
+    xpBar.BackgroundTransparency = xpConfig.BackgroundTransparency or 0.45
+    xpBar.BorderSizePixel = 0
+    xpBar.Size = UDim2.new(1, 0, 0, xpConfig.BarHeight or 18)
+    xpBar.LayoutOrder = 2
+    xpBar.Parent = xpPanel
+
+    local xpBarCorner = Instance.new("UICorner")
+    xpBarCorner.CornerRadius = UDim.new(0, xpConfig.CornerRadius or 9)
+    xpBarCorner.Parent = xpBar
+
+    local xpFill = Instance.new("Frame")
+    xpFill.Name = "Fill"
+    xpFill.BackgroundColor3 = xpConfig.FillColor or Color3.fromRGB(88, 182, 255)
+    xpFill.BackgroundTransparency = xpConfig.FillTransparency or 0.05
+    xpFill.BorderSizePixel = 0
+    xpFill.Size = UDim2.new(0, 0, 1, 0)
+    xpFill.Parent = xpBar
+
+    local xpFillCorner = Instance.new("UICorner")
+    xpFillCorner.CornerRadius = UDim.new(0, xpConfig.CornerRadius or 9)
+    xpFillCorner.Parent = xpFill
 
     local alertArea = Instance.new("Frame")
     alertArea.Name = "AlertArea"
     alertArea.BackgroundTransparency = 1
-    alertArea.AnchorPoint = Vector2.new(0.5, 0)
-    alertArea.Position = UDim2.new(0.5, 0, 0, topBarHeight + (uiConfig.AlertAreaOffset or 12))
-    alertArea.Size = UDim2.new(0, uiConfig.AlertAreaWidth or 460, 0, uiConfig.AlertAreaHeight or 160)
+    alertArea.Position = UDim2.new(0, sidePanelWidth + sectionSpacing, 0, uiConfig.AlertAreaOffset or 12)
+    alertArea.Size = UDim2.new(1, -(sidePanelWidth + sectionSpacing), 0, uiConfig.AlertAreaHeight or 160)
     alertArea.Parent = safeFrame
 
     local alertLayout = Instance.new("UIListLayout")
@@ -225,22 +252,11 @@ function HUDController:CreateInterface(playerGui: PlayerGui)
     messageLabel.TextTransparency = 1
     messageLabel.Size = UDim2.new(1, 0, 0, uiConfig.MessageHeight or 40)
 
-    local reservedAlert = Instance.new("Frame")
-    reservedAlert.Name = "ReservedAlerts"
-    reservedAlert.BackgroundTransparency = uiConfig.AlertBackgroundTransparency or 0.35
-    reservedAlert.BackgroundColor3 = uiConfig.AlertBackgroundColor or Color3.fromRGB(18, 24, 32)
-    reservedAlert.Size = UDim2.new(1, 0, 0, uiConfig.ReservedAlertHeight or 52)
-    reservedAlert.LayoutOrder = 0
-    reservedAlert.Parent = alertArea
-
-    local reservedLabel = createTextLabel(reservedAlert, "", font, alertTextSize, Enum.TextXAlignment.Center)
-    reservedLabel.Text = ""
-
     local partyContainer = Instance.new("Frame")
     partyContainer.Name = "PartyContainer"
     partyContainer.BackgroundTransparency = 1
-    partyContainer.AnchorPoint = Vector2.new(1, 0.5)
-    partyContainer.Position = UDim2.new(1, 0, 0.5, 0)
+    partyContainer.AnchorPoint = Vector2.new(1, 0)
+    partyContainer.Position = UDim2.new(1, 0, 0, sectionSpacing)
     partyContainer.Size = UDim2.new(0, uiConfig.Party and uiConfig.Party.Width or 220, 0, 10)
     partyContainer.AutomaticSize = Enum.AutomaticSize.Y
     partyContainer.Parent = safeFrame
@@ -258,56 +274,97 @@ function HUDController:CreateInterface(playerGui: PlayerGui)
     partyEmptyLabel.TextTransparency = 0.45
     partyEmptyLabel.Text = ""
 
-    local xpConfig = uiConfig.XP or {}
-    local xpBarWidth = xpConfig.BarWidth or 360
-    local xpBarHeight = xpConfig.BarHeight or 18
-    local xpLevelWidth = xpConfig.LevelWidth or 54
-    local xpSpacing = xpConfig.LevelSpacing or 10
-    local xpContainerWidth = xpBarWidth + xpSpacing + xpLevelWidth
+    local abilityFrame = Instance.new("Frame")
+    abilityFrame.Name = "AbilityFrame"
+    abilityFrame.BackgroundTransparency = 1
+    abilityFrame.AnchorPoint = Vector2.new(0, 1)
+    abilityFrame.Position = UDim2.new(0, 0, 1, -abilityBottomOffset)
+    abilityFrame.Size = UDim2.new(0, abilityWidth, 0, abilityHeight)
+    abilityFrame.Parent = safeFrame
 
-    local xpContainer = Instance.new("Frame")
-    xpContainer.Name = "XPContainer"
-    xpContainer.BackgroundTransparency = 1
-    xpContainer.AnchorPoint = Vector2.new(0.5, 1)
-    xpContainer.Position = UDim2.new(0.5, 0, 1, 0)
-    xpContainer.Size = UDim2.new(0, xpContainerWidth, 0, xpBarHeight + (xpConfig.LabelHeight or 18))
-    xpContainer.Parent = safeFrame
+    local skillLabel = createTextLabel(abilityFrame, "", boldFont, abilityConfig.SkillTextSize or infoTextSize, Enum.TextXAlignment.Left)
+    skillLabel.Size = UDim2.new(0, abilitySkillWidth, 0, abilitySkillHeight)
+    skillLabel.Position = UDim2.new(0, 0, 0, math.max(0, math.floor((abilityHeight - abilitySkillHeight) / 2)))
+    skillLabel.TextScaled = false
+    skillLabel.TextWrapped = true
 
-    local xpBar = Instance.new("Frame")
-    xpBar.Name = "XPBar"
-    xpBar.BackgroundColor3 = xpConfig.BackgroundColor or Color3.fromRGB(18, 24, 32)
-    xpBar.BackgroundTransparency = xpConfig.BackgroundTransparency or 0.45
-    xpBar.BorderSizePixel = 0
-    xpBar.Size = UDim2.new(0, xpBarWidth, 0, xpBarHeight)
-    xpBar.Position = UDim2.new(0, 0, 0, (xpConfig.LabelHeight or 18))
-    xpBar.Parent = xpContainer
+    local dashContainer = Instance.new("Frame")
+    dashContainer.Name = "DashContainer"
+    dashContainer.BackgroundTransparency = 1
+    dashContainer.Size = UDim2.new(0, dashSize, 0, dashSize)
+    dashContainer.Position = UDim2.new(0, abilitySkillWidth + abilitySpacing, 0, math.max(0, math.floor((abilityHeight - dashSize) / 2)))
+    dashContainer.Parent = abilityFrame
 
-    local xpBarCorner = Instance.new("UICorner")
-    xpBarCorner.CornerRadius = UDim.new(0, xpConfig.CornerRadius or 9)
-    xpBarCorner.Parent = xpBar
+    local dashSlot = Instance.new("Frame")
+    dashSlot.Name = "DashSlot"
+    dashSlot.BackgroundTransparency = 1
+    dashSlot.Size = UDim2.fromScale(1, 1)
+    dashSlot.Parent = dashContainer
 
-    local xpFill = Instance.new("Frame")
-    xpFill.Name = "Fill"
-    xpFill.BackgroundColor3 = xpConfig.FillColor or Color3.fromRGB(88, 182, 255)
-    xpFill.BackgroundTransparency = xpConfig.FillTransparency or 0.05
-    xpFill.BorderSizePixel = 0
-    xpFill.Size = UDim2.new(0, 0, 1, 0)
-    xpFill.Parent = xpBar
+    local dashGauge = Instance.new("Frame")
+    dashGauge.Name = "Gauge"
+    dashGauge.Size = UDim2.fromScale(1, 1)
+    dashGauge.BackgroundColor3 = dashConfig.BackgroundColor or Color3.fromRGB(18, 24, 32)
+    dashGauge.BackgroundTransparency = dashConfig.BackgroundTransparency or 0.25
+    dashGauge.BorderSizePixel = 0
+    dashGauge.Parent = dashSlot
 
-    local xpFillCorner = Instance.new("UICorner")
-    xpFillCorner.CornerRadius = UDim.new(0, xpConfig.CornerRadius or 9)
-    xpFillCorner.Parent = xpFill
+    local dashCorner = Instance.new("UICorner")
+    dashCorner.CornerRadius = UDim.new(1, 0)
+    dashCorner.Parent = dashGauge
 
-    local xpLabel = createTextLabel(xpContainer, "XP 0 / 0", font, xpConfig.LabelTextSize or smallTextSize, Enum.TextXAlignment.Left)
-    xpLabel.Position = UDim2.new(0, 0, 0, 0)
-    xpLabel.Size = UDim2.new(0, xpBarWidth, 0, xpConfig.LabelHeight or 18)
+    local dashStroke = Instance.new("UIStroke")
+    dashStroke.Thickness = dashConfig.StrokeThickness or 2
+    dashStroke.Color = dashConfig.StrokeColor or Color3.fromRGB(120, 200, 255)
+    dashStroke.Transparency = dashConfig.StrokeTransparency or 0.2
+    dashStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+    dashStroke.Parent = dashGauge
 
-    local levelLabel = createTextLabel(xpContainer, "Lv 1", boldFont, xpConfig.LevelTextSize or alertTextSize, Enum.TextXAlignment.Center)
-    levelLabel.AnchorPoint = Vector2.new(0, 0.5)
-    levelLabel.Position = UDim2.new(0, xpBarWidth + xpSpacing, 0, (xpConfig.LabelHeight or 18) + xpBarHeight / 2)
-    levelLabel.Size = UDim2.new(0, xpLevelWidth, 0, xpBarHeight)
+    local dashMask = Instance.new("Frame")
+    dashMask.Name = "Mask"
+    dashMask.BackgroundTransparency = 1
+    dashMask.Size = UDim2.fromScale(1, 1)
+    dashMask.ClipsDescendants = true
+    dashMask.Parent = dashGauge
+
+    local dashMaskCorner = Instance.new("UICorner")
+    dashMaskCorner.CornerRadius = UDim.new(1, 0)
+    dashMaskCorner.Parent = dashMask
+
+    local dashFill = Instance.new("Frame")
+    dashFill.Name = "Fill"
+    dashFill.BorderSizePixel = 0
+    dashFill.BackgroundColor3 = dashConfig.FillColor or Color3.fromRGB(120, 200, 255)
+    dashFill.BackgroundTransparency = dashConfig.FillTransparency or 0.15
+    dashFill.AnchorPoint = Vector2.new(0, 1)
+    dashFill.Position = UDim2.new(0, 0, 1, 0)
+    dashFill.Size = UDim2.new(1, 0, 0, 0)
+    dashFill.Parent = dashMask
+
+    local dashFillCorner = Instance.new("UICorner")
+    dashFillCorner.CornerRadius = UDim.new(1, 0)
+    dashFillCorner.Parent = dashFill
+
+    local dashKeyLabel = createTextLabel(dashGauge, dashConfig.KeyText or "E", boldFont, smallTextSize, Enum.TextXAlignment.Center)
+    dashKeyLabel.AnchorPoint = Vector2.new(0.5, 0.5)
+    dashKeyLabel.Position = UDim2.new(0.5, 0, 0.3, 0)
+    dashKeyLabel.TextScaled = true
+
+    local dashCooldownLabel = createTextLabel(dashGauge, dashConfig.ReadyText or "Ready", boldFont, smallTextSize, Enum.TextXAlignment.Center)
+    dashCooldownLabel.AnchorPoint = Vector2.new(0.5, 0.5)
+    dashCooldownLabel.Position = UDim2.new(0.5, 0, 0.72, 0)
+    dashCooldownLabel.TextScaled = true
+    dashCooldownLabel.TextColor3 = dashConfig.ReadyColor or Color3.fromRGB(180, 255, 205)
 
     self.Screen = screen
+    self.SkillDisplayKey = abilityConfig.SkillKey or "Q"
+    self.SkillReadyText = abilityConfig.SkillReadyText or "Ready"
+    self.PrimarySkillId = abilityConfig.PrimarySkillId or "AOE_Blast"
+    self.DashReadyText = dashConfig.ReadyText or "Ready"
+    self.DashReadyColor = dashConfig.ReadyColor or Color3.fromRGB(180, 255, 205)
+
+    skillLabel.Text = string.format("%s: %s", self.SkillDisplayKey, self.SkillReadyText)
+
     self.Elements = {
         WaveLabel = waveLabel,
         EnemyLabel = enemyLabel,
@@ -318,8 +375,6 @@ function HUDController:CreateInterface(playerGui: PlayerGui)
         DashCooldownLabel = dashCooldownLabel,
         MessageLabel = messageLabel,
         WaveAnnouncement = waveAnnouncement,
-        ReservedAlert = reservedAlert,
-        ReservedAlertLabel = reservedLabel,
         PartyContainer = partyContainer,
         PartyEmptyLabel = partyEmptyLabel,
         XPFill = xpFill,
@@ -328,7 +383,6 @@ function HUDController:CreateInterface(playerGui: PlayerGui)
         XPBar = xpBar,
     }
 end
-
 local function formatTime(seconds: number): string
     seconds = math.max(0, math.floor(seconds + 0.5))
     local minutes = math.floor(seconds / 60)
@@ -345,6 +399,11 @@ function HUDController:Update(state)
     self.Elements.WaveLabel.Text = string.format("Wave %d", wave)
 
     local enemies = state.RemainingEnemies or 0
+    if typeof(enemies) == "number" then
+        enemies = math.max(0, math.floor(enemies + 0.5))
+    else
+        enemies = 0
+    end
     self.Elements.EnemyLabel.Text = string.format("Enemies: %d", enemies)
 
     if state.Countdown and state.Countdown > 0 then
@@ -355,7 +414,13 @@ function HUDController:Update(state)
         self.Elements.TimerLabel.Text = "Time: ∞"
     end
 
-    self.Elements.GoldLabel.Text = string.format("Gold: %d", state.Gold or 0)
+    local gold = state.Gold or 0
+    if typeof(gold) == "number" then
+        gold = math.floor(gold + 0.5)
+    else
+        gold = 0
+    end
+    self.Elements.GoldLabel.Text = string.format("Gold: %d", gold)
 
     self:UpdateXP(state)
     self:UpdateSkillCooldowns(state.SkillCooldowns)
@@ -372,8 +437,15 @@ function HUDController:UpdateXP(state)
         return
     end
 
-    local level = state.Level or 1
-    levelLabel.Text = string.format("Lv %d", level)
+    local xpConfig = Config.UI and Config.UI.XP or {}
+    local prefix = xpConfig.LabelPrefix or "XP"
+
+    local levelValue = tonumber(state.Level)
+    if levelValue then
+        levelLabel.Text = string.format("Lv %d", math.max(1, math.floor(levelValue + 0.5)))
+    else
+        levelLabel.Text = "Lv 1"
+    end
 
     local progress = state.XPProgress
     local current = 0
@@ -413,14 +485,18 @@ function HUDController:UpdateXP(state)
         end
     end
 
-    xpFill.Size = UDim2.new(ratio, 0, 1, 0)
+    local totalXP = state.XP or current
+
+    xpFill.Size = UDim2.new(math.clamp(ratio, 0, 1), 0, 1, 0)
 
     if required > 0 then
-        xpLabel.Text = string.format("XP %d / %d", math.floor(current + 0.5), math.floor(required + 0.5))
+        xpLabel.Text = string.format("%s %d / %d", prefix, math.floor(current + 0.5), math.floor(required + 0.5))
     elseif ratio > 0 then
-        xpLabel.Text = string.format("XP %d%%", math.floor(ratio * 100 + 0.5))
+        xpLabel.Text = string.format("%s %d%%", prefix, math.floor(ratio * 100 + 0.5))
+    elseif typeof(totalXP) == "number" then
+        xpLabel.Text = string.format("%s %d", prefix, math.floor(totalXP + 0.5))
     else
-        xpLabel.Text = "XP 0 / ?"
+        xpLabel.Text = prefix
     end
 end
 
@@ -430,10 +506,22 @@ function HUDController:UpdateSkillCooldowns(skillTable)
         return
     end
 
+    local primaryId = self.PrimarySkillId
+    if not primaryId then
+        local abilityConfig = Config.UI and Config.UI.Abilities
+        if abilityConfig then
+            primaryId = abilityConfig.PrimarySkillId
+        end
+        primaryId = primaryId or "AOE_Blast"
+    end
+
     local info
     if typeof(skillTable) == "table" then
-        info = skillTable.AOE_Blast or skillTable.Primary
-        if not info then
+        if primaryId and typeof(skillTable[primaryId]) == "table" then
+            info = skillTable[primaryId]
+        elseif typeof(skillTable.Primary) == "table" then
+            info = skillTable.Primary
+        else
             for _, entry in pairs(skillTable) do
                 if typeof(entry) == "table" then
                     info = entry
@@ -442,6 +530,9 @@ function HUDController:UpdateSkillCooldowns(skillTable)
             end
         end
     end
+
+    local keyText = self.SkillDisplayKey or "Q"
+    local readyText = self.SkillReadyText or "Ready"
 
     if info and typeof(info) == "table" then
         local cooldown = 0
@@ -453,17 +544,22 @@ function HUDController:UpdateSkillCooldowns(skillTable)
             remaining = math.max(0, info.Remaining)
         elseif typeof(info.Timestamp) == "number" then
             local now = Workspace:GetServerTimeNow()
-            local elapsed = now - info.Timestamp
-            remaining = math.max(0, cooldown - elapsed)
+            local endTime = info.EndTime
+            if typeof(endTime) == "number" then
+                remaining = math.max(0, endTime - now)
+            else
+                local elapsed = now - info.Timestamp
+                remaining = math.max(0, cooldown - elapsed)
+            end
         end
 
-        if remaining and remaining > 0 then
-            skillLabel.Text = string.format("Q: %.1fs", remaining)
+        if remaining and remaining > 0.05 then
+            skillLabel.Text = string.format("%s: %.1fs", keyText, remaining)
             return
         end
     end
 
-    skillLabel.Text = "Q: Ready"
+    skillLabel.Text = string.format("%s: %s", keyText, readyText)
 end
 
 function HUDController:UpdateDashCooldown(dashData)
@@ -496,9 +592,12 @@ function HUDController:UpdateDashCooldown(dashData)
 
     dashFill.Size = UDim2.new(1, 0, progress, 0)
 
+    local readyText = self.DashReadyText or "Ready"
+    local readyColor = self.DashReadyColor or Color3.fromRGB(180, 255, 205)
+
     if remaining <= 0.05 then
-        dashCooldownLabel.Text = "Ready"
-        dashCooldownLabel.TextColor3 = Color3.fromRGB(180, 255, 205)
+        dashCooldownLabel.Text = readyText
+        dashCooldownLabel.TextColor3 = readyColor
     else
         dashCooldownLabel.Text = string.format("%.1f", remaining)
         dashCooldownLabel.TextColor3 = Color3.new(1, 1, 1)


### PR DESCRIPTION
## Summary
- redesign the HUD to use a left-aligned status panel with clearer gold, wave, timer, and XP displays while respecting the Roblox top bar inset
- track skill and dash cooldowns locally using server timestamps so Q and E counters stay accurate between remote updates
- keep the timer, countdown, and enemy counts responsive on the client by extrapolating state and listening for spawn/remove events
- remove the unused reserved alert panel so no empty dark bar appears in the center of the HUD

## Testing
- not run (Roblox environment)

------
https://chatgpt.com/codex/tasks/task_e_68d3f83521bc83338c6173377e5e4c90