### PR TITLE
Attach HUD to prebuilt UI and fix dash physics

### DIFF
--- a/src/client/Controllers/UIController.lua
+++ b/src/client/Controllers/UIController.lua
@@ -40,8 +40,12 @@ end
 function UIController:KnitStart()
     local playerGui = Players.LocalPlayer:WaitForChild("PlayerGui")
     self.HUD = Knit.GetController("HUDController")
-    if self.HUD and self.HUD.CreateInterface and not self.HUD.Screen then
-        self.HUD:CreateInterface(playerGui)
+    if self.HUD and self.HUD.OnInterfaceReady then
+        self.HUD:OnInterfaceReady(function()
+            if self.HUD then
+                self.HUD:Update(self.State)
+            end
+        end)
     end
     self.ResultScreen = ResultScreen.new(playerGui)
 

--- a/src/server/Services/DashService.lua
+++ b/src/server/Services/DashService.lua
@@ -35,6 +35,8 @@ local DashService = Knit.CreateService({
     Client = {},
 })
 
+local DASH_PHYSICAL_PROPERTIES = PhysicalProperties.new(0.0001, 0, 0, 0, 0)
+
 function DashService:KnitInit()
     self.ActiveDashes = {} :: {[Player]: DashState}
     self.CooldownThreads = {} :: {[Player]: thread}
@@ -225,7 +227,7 @@ function DashService:HandleDashRequest(player: Player, rawDirection)
     self.LastDashReadyTime[player] = nextReadyTime
 
     humanoid.AutoRotate = false
-    root.CustomPhysicalProperties = PhysicalProperties.new(0, 0, 0, 0, 0)
+    root.CustomPhysicalProperties = DASH_PHYSICAL_PROPERTIES
     character:SetAttribute("IFrame", true)
     self:ScheduleIFrameClear(character, dashConfig.IFrame)
 

--- a/src/server/Services/EnemyService.lua
+++ b/src/server/Services/EnemyService.lua
@@ -15,16 +15,22 @@ local function applyCollisionGroup(instance: Instance, groupName: string)
         return
     end
 
+    local function setCollisionGroup(part: BasePart)
+        if part.CollisionGroup ~= groupName then
+            part.CollisionGroup = groupName
+        end
+    end
+
     for _, descendant in ipairs(instance:GetDescendants()) do
         if descendant:IsA("BasePart") then
-            PhysicsService:SetPartCollisionGroup(descendant, groupName)
+            setCollisionGroup(descendant)
         end
     end
 
     if instance:IsA("Model") then
         instance.DescendantAdded:Connect(function(descendant)
             if descendant:IsA("BasePart") then
-                PhysicsService:SetPartCollisionGroup(descendant, groupName)
+                setCollisionGroup(descendant)
             end
         end)
     end
@@ -56,11 +62,21 @@ function EnemyService:EnsureCollisionGroups()
             return
         end
 
-        local exists = pcall(function()
+        local success, exists = pcall(function()
+            if PhysicsService.CollisionGroupExists then
+                return PhysicsService:CollisionGroupExists(name)
+            end
+
             PhysicsService:GetCollisionGroupId(name)
+            return true
         end)
-        if not exists then
-            PhysicsService:CreateCollisionGroup(name)
+
+        if not success or not exists then
+            if PhysicsService.RegisterCollisionGroup then
+                PhysicsService:RegisterCollisionGroup(name)
+            else
+                PhysicsService:CreateCollisionGroup(name)
+            end
         end
     end
 

--- a/src/server/Services/GameStateService.lua
+++ b/src/server/Services/GameStateService.lua
@@ -79,11 +79,21 @@ function GameStateService:EnsureCollisionGroups()
             return
         end
 
-        local exists = pcall(function()
+        local success, exists = pcall(function()
+            if PhysicsService.CollisionGroupExists then
+                return PhysicsService:CollisionGroupExists(name)
+            end
+
             PhysicsService:GetCollisionGroupId(name)
+            return true
         end)
-        if not exists then
-            PhysicsService:CreateCollisionGroup(name)
+
+        if not success or not exists then
+            if PhysicsService.RegisterCollisionGroup then
+                PhysicsService:RegisterCollisionGroup(name)
+            else
+                PhysicsService:CreateCollisionGroup(name)
+            end
         end
     end
 
@@ -108,15 +118,21 @@ function GameStateService:ApplyCharacterCollisionGroup(character: Model)
         return
     end
 
+    local function setCollisionGroup(part: BasePart)
+        if part.CollisionGroup ~= groupName then
+            part.CollisionGroup = groupName
+        end
+    end
+
     for _, descendant in ipairs(character:GetDescendants()) do
         if descendant:IsA("BasePart") then
-            PhysicsService:SetPartCollisionGroup(descendant, groupName)
+            setCollisionGroup(descendant)
         end
     end
 
     character.DescendantAdded:Connect(function(descendant)
         if descendant:IsA("BasePart") then
-            PhysicsService:SetPartCollisionGroup(descendant, groupName)
+            setCollisionGroup(descendant)
         end
     end)
 end

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -368,7 +368,7 @@
                 "FillDirection": "Vertical",
                 "SortOrder": "LayoutOrder",
                 "Padding": { "UDim": [0, 8] },
-                "HorizontalAlignment": "Stretch",
+                "HorizontalAlignment": "Left",
                 "VerticalAlignment": "Top"
               }
             },


### PR DESCRIPTION
## Summary
- let the HUD controller attach to the prebuilt `SkillSurvivalHUD` ScreenGui instead of instancing it at runtime, and expose an `OnInterfaceReady` signal
- update the UI controller to wait for the HUD interface and immediately refresh cooldown state when it appears so the Q and E gauges populate
- reuse a safe PhysicalProperties preset during dashes to avoid Roblox clamping warnings about density

## Testing
- not run (Roblox environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d560dab8b8833393011b025b75111a