### PR TITLE
Fix syntax error in UIController KnitStart

### DIFF
--- a/src/client/Controllers/UIController.lua
+++ b/src/client/Controllers/UIController.lua
@@ -118,37 +118,6 @@ function UIController:KnitStart()
         self.ResultScreen:Show(summary)
     end)
 
-
-function UIController:KnitStart()
-    local playerGui = Players.LocalPlayer:WaitForChild("PlayerGui")
-    self.HUD = Knit.GetController("HUDController")
-    if self.HUD and self.HUD.OnInterfaceReady then
-        self.HUD:OnInterfaceReady(function()
-            if self.HUD then
-                self.HUD:Update(self.State)
-            end
-        end)
-    end
-    self.ResultScreen = ResultScreen.new(playerGui)
-
-    Net:GetEvent("HUD").OnClientEvent:Connect(function(payload)
-        self:ApplyHUDUpdate(payload)
-    end)
-
-    Net:GetEvent("GameState").OnClientEvent:Connect(function(data)
-        if data.Type == "WaveStart" then
-            self.HUD:PlayWaveAnnouncement(data.Wave)
-        elseif data.Type == "TeleportFailed" then
-            self.HUD:ShowMessage("Teleport failed: " .. tostring(data.Message))
-        end
-    end)
-
-    Net:GetEvent("Result").OnClientEvent:Connect(function(summary)
-        self.HUD:ShowMessage("Session ended: " .. tostring(summary.Reason))
-        self.ResultScreen:Show(summary)
-    end)
-
-
     Net:GetEvent("DashCooldown").OnClientEvent:Connect(function(data)
         self:OnDashCooldown(data)
     end)


### PR DESCRIPTION
## Summary
- remove a duplicated KnitStart definition in UIController
- ensure the UI controller's event connections live inside a single KnitStart implementation

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d65f73083c833396f9136983a5ee07