### PR TITLE
Fix HUDController interface callbacks

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -213,34 +213,11 @@ function HUDController:OnInterfaceReady(callback)
         task.defer(callback, self.Screen)
     end
 
-
+    if not self.InterfaceSignal then
+        local signal = Instance.new("BindableEvent")
+        signal.Name = "HUDInterfaceReady"
+        self.InterfaceSignal = signal
     end
-
-    playerGui.ChildAdded:Connect(function(child)
-        if child.Name == "SkillSurvivalHUD" then
-            task.defer(tryAttach, child)
-        end
-    end)
-end
-
-function HUDController:KnitShutdown()
-    if self.InterfaceSignal then
-        self.InterfaceSignal:Destroy()
-        self.InterfaceSignal = nil
-    end
-    self.Screen = nil
-    self.Elements = {}
-end
-
-function HUDController:OnInterfaceReady(callback)
-    if typeof(callback) ~= "function" then
-        return nil
-    end
-
-    if self.Screen then
-        task.defer(callback, self.Screen)
-    end
-
 
     return self.InterfaceSignal.Event:Connect(callback)
 end

--- a/src/client/Controllers/UIController.lua
+++ b/src/client/Controllers/UIController.lua
@@ -118,37 +118,6 @@ function UIController:KnitStart()
         self.ResultScreen:Show(summary)
     end)
 
-
-function UIController:KnitStart()
-    local playerGui = Players.LocalPlayer:WaitForChild("PlayerGui")
-    self.HUD = Knit.GetController("HUDController")
-    if self.HUD and self.HUD.OnInterfaceReady then
-        self.HUD:OnInterfaceReady(function()
-            if self.HUD then
-                self.HUD:Update(self.State)
-            end
-        end)
-    end
-    self.ResultScreen = ResultScreen.new(playerGui)
-
-    Net:GetEvent("HUD").OnClientEvent:Connect(function(payload)
-        self:ApplyHUDUpdate(payload)
-    end)
-
-    Net:GetEvent("GameState").OnClientEvent:Connect(function(data)
-        if data.Type == "WaveStart" then
-            self.HUD:PlayWaveAnnouncement(data.Wave)
-        elseif data.Type == "TeleportFailed" then
-            self.HUD:ShowMessage("Teleport failed: " .. tostring(data.Message))
-        end
-    end)
-
-    Net:GetEvent("Result").OnClientEvent:Connect(function(summary)
-        self.HUD:ShowMessage("Session ended: " .. tostring(summary.Reason))
-        self.ResultScreen:Show(summary)
-    end)
-
-
     Net:GetEvent("DashCooldown").OnClientEvent:Connect(function(data)
         self:OnDashCooldown(data)
     end)

--- a/src/shared/Knit/init.lua
+++ b/src/shared/Knit/init.lua
@@ -54,6 +54,14 @@ function Knit.GetService(name: string)
     return service
 end
 
+function Knit.GetController(name: string)
+    local controller = Knit.Controllers[name]
+    if not controller then
+        error("[Knit] Controller not found: " .. tostring(name))
+    end
+    return controller
+end
+
 function Knit.CreateController(controllerDef)
     assert(not isServer, "Knit.CreateController can only be used on the client")
     assert(controllerDef and controllerDef.Name, "Controller definition requires a Name")


### PR DESCRIPTION
## Summary
- remove duplicate KnitShutdown and OnInterfaceReady blocks that left stray `end` statements in HUDController
- recreate the HUD interface signal on demand when registering callbacks
- add a `Knit.GetController` helper so client controllers like the UI can safely resolve the HUD controller

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d65f73083c833396f9136983a5ee07