### PR TITLE
Fix ResultScreen ScreenGui detection

### DIFF
--- a/src/client/UI/ResultScreen.lua
+++ b/src/client/UI/ResultScreen.lua
@@ -27,8 +27,6 @@ function ResultScreen.new(playerGui: PlayerGui)
     local screen = playerGui:WaitForChild("ResultScreen")
     if not screen:IsA("ScreenGui") then
         local descendant = waitForDescendantOfClass(screen, "ScreenGui")
-        if not descendant then
-        local descendant = screen:FindFirstChildWhichIsA("ScreenGui", true)
         if descendant then
             screen = descendant
         else
@@ -39,9 +37,6 @@ function ResultScreen.new(playerGui: PlayerGui)
                 )
             )
         end
-
-        screen = descendant
-
     end
 
     local container = screen:WaitForChild("Container")


### PR DESCRIPTION
## Summary
- remove leftover merge conflict code when resolving the ResultScreen ScreenGui fallback
- ensure the ResultScreen falls back to a nested ScreenGui or errors with a clear message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6903a45308333ba8e54fd155c86fe