### PR TITLE
Update HUD XP layout and cooldown readouts

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -132,19 +132,16 @@ local function resolveCooldownSlot(root: Instance?)
 
     local slot = root:FindFirstChild("Slot")
     local gauge = slot and slot:FindFirstChild("Gauge")
-    local mask = gauge and gauge:FindFirstChild("Mask")
-    local fill = mask and mask:FindFirstChild("Fill")
     local cooldownLabel = gauge and gauge:FindFirstChild("CooldownLabel")
     local keyLabel = gauge and gauge:FindFirstChild("KeyLabel")
 
-    if not (slot and gauge and mask and fill and cooldownLabel and keyLabel) then
+    if not (slot and gauge and cooldownLabel and keyLabel) then
         return nil
     end
 
     return {
         Container = root,
         Gauge = gauge,
-        Fill = fill,
         CooldownLabel = cooldownLabel,
         KeyLabel = keyLabel,
     }
@@ -386,11 +383,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         skillStroke.Transparency = abilityConfig.SkillStrokeTransparency or 0.2
         skillStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
     end
-    if skill.Fill then
-        skill.Fill.Visible = false
-        skill.Fill.BackgroundTransparency = 1
-    end
-
     dash.Gauge.BackgroundColor3 = dashConfig.BackgroundColor or Color3.fromRGB(18, 24, 32)
     dash.Gauge.BackgroundTransparency = dashConfig.BackgroundTransparency or 0.25
     local dashStroke = dash.Gauge:FindFirstChildWhichIsA("UIStroke")
@@ -400,16 +392,12 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         dashStroke.Transparency = dashConfig.StrokeTransparency or 0.2
         dashStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
     end
-    if dash.Fill then
-        dash.Fill.Visible = false
-        dash.Fill.BackgroundTransparency = 1
-    end
 
     self.Screen = screen
     self.SkillDisplayKey = abilityConfig.SkillKey or "Q"
     local skillReadyText = abilityConfig.SkillReadyText
     if skillReadyText == nil then
-        skillReadyText = "0"
+        skillReadyText = "0.0"
     else
         skillReadyText = tostring(skillReadyText)
     end
@@ -418,7 +406,7 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
     self.PrimarySkillId = abilityConfig.PrimarySkillId or "AOE_Blast"
     local dashReadyText = dashConfig.ReadyText
     if dashReadyText == nil then
-        dashReadyText = "0"
+        dashReadyText = "0.0"
     else
         dashReadyText = tostring(dashReadyText)
     end
@@ -529,12 +517,13 @@ function HUDController:UpdateXP(state)
 
     local xpConfig = Config.UI and Config.UI.XP or {}
     local prefix = xpConfig.LabelPrefix or "XP"
+    prefix = string.gsub(prefix, "%s+$", "")
 
     local levelValue = tonumber(state.Level)
     if levelValue then
-        levelLabel.Text = string.format("Lv %d", math.max(1, math.floor(levelValue + 0.5)))
+        levelLabel.Text = string.format("Lv%d", math.max(1, math.floor(levelValue + 0.5)))
     else
-        levelLabel.Text = "Lv 1"
+        levelLabel.Text = "Lv1"
     end
 
     local progress = state.XPProgress
@@ -580,13 +569,13 @@ function HUDController:UpdateXP(state)
     xpFill.Size = UDim2.new(math.clamp(ratio, 0, 1), 0, 1, 0)
 
     if required > 0 then
-        xpLabel.Text = string.format("%s %d / %d", prefix, math.floor(current + 0.5), math.floor(required + 0.5))
+        xpLabel.Text = string.format("%s%d/%d", prefix, math.floor(current + 0.5), math.floor(required + 0.5))
     elseif ratio > 0 then
-        xpLabel.Text = string.format("%s %d%%", prefix, math.floor(ratio * 100 + 0.5))
+        xpLabel.Text = string.format("%s%d%%", prefix, math.floor(ratio * 100 + 0.5))
     elseif typeof(totalXP) == "number" then
-        xpLabel.Text = string.format("%s %d", prefix, math.floor(totalXP + 0.5))
+        xpLabel.Text = string.format("%s%d", prefix, math.floor(totalXP + 0.5))
     else
-        xpLabel.Text = prefix
+        xpLabel.Text = string.format("%s0", prefix)
     end
 end
 
@@ -655,7 +644,8 @@ function HUDController:UpdateSkillCooldowns(skillTable)
     end
 
     if remaining > 0.05 then
-        cooldownLabel.Text = tostring(math.ceil(remaining))
+        local displayValue = math.floor((remaining * 10) + 0.5) / 10
+        cooldownLabel.Text = string.format("%.1f", displayValue)
         cooldownLabel.TextColor3 = Color3.new(1, 1, 1)
         cooldownLabel.TextStrokeTransparency = 0.6
         cooldownLabel.Visible = true
@@ -693,7 +683,8 @@ function HUDController:UpdateDashCooldown(dashData)
         dashCooldownLabel.TextStrokeTransparency = 0.6
         dashCooldownLabel.Visible = true
     else
-        dashCooldownLabel.Text = tostring(math.ceil(remaining))
+        local displayValue = math.floor((remaining * 10) + 0.5) / 10
+        dashCooldownLabel.Text = string.format("%.1f", displayValue)
         dashCooldownLabel.TextColor3 = Color3.new(1, 1, 1)
         dashCooldownLabel.TextStrokeTransparency = 0.6
         dashCooldownLabel.Visible = true

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -195,19 +195,13 @@
                     "LayoutOrder": 1
                   },
                   "$children": {
-                    "XPText": {
-                      "$className": "TextLabel",
+                    "UIListLayout": {
+                      "$className": "UIListLayout",
                       "$properties": {
-                        "Name": "XPText",
-                        "BackgroundTransparency": 1,
-                        "Font": "Gotham",
-                        "Text": "XP 0",
-                        "TextSize": 18,
-                        "TextColor3": { "Color3": [1, 1, 1] },
-                        "TextStrokeTransparency": 0.6,
-                        "TextXAlignment": "Left",
-                        "TextYAlignment": "Center",
-                        "Size": { "UDim2": [1, -72, 1, 0] }
+                        "FillDirection": "Horizontal",
+                        "HorizontalAlignment": "Left",
+                        "VerticalAlignment": "Center",
+                        "Padding": { "UDim": [0, 8] }
                       }
                     },
                     "LevelLabel": {
@@ -216,15 +210,30 @@
                         "Name": "LevelLabel",
                         "BackgroundTransparency": 1,
                         "Font": "GothamBold",
-                        "Text": "Lv 1",
+                        "Text": "Lv1",
                         "TextSize": 24,
+                        "TextColor3": { "Color3": [1, 1, 1] },
+                        "TextStrokeTransparency": 0.6,
+                        "TextXAlignment": "Left",
+                        "TextYAlignment": "Center",
+                        "Size": { "UDim2": [0, 72, 1, 0] },
+                        "LayoutOrder": 1
+                      }
+                    },
+                    "XPText": {
+                      "$className": "TextLabel",
+                      "$properties": {
+                        "Name": "XPText",
+                        "BackgroundTransparency": 1,
+                        "Font": "Gotham",
+                        "Text": "XP0",
+                        "TextSize": 18,
                         "TextColor3": { "Color3": [1, 1, 1] },
                         "TextStrokeTransparency": 0.6,
                         "TextXAlignment": "Right",
                         "TextYAlignment": "Center",
-                        "AnchorPoint": { "Vector2": [1, 0.5] },
-                        "Position": { "UDim2": [1, 0, 0.5, 0] },
-                        "Size": { "UDim2": [0, 60, 1, 0] }
+                        "Size": { "UDim2": [1, -80, 1, 0] },
+                        "LayoutOrder": 2
                       }
                     }
                   }
@@ -414,43 +423,6 @@
                             "ApplyStrokeMode": "Border"
                           }
                         },
-                        "Mask": {
-                          "$className": "Frame",
-                          "$properties": {
-                            "Name": "Mask",
-                            "BackgroundTransparency": 1,
-                            "Size": { "UDim2": [1, 0, 1, 0] },
-                            "ClipsDescendants": true
-                          },
-                          "$children": {
-                            "UICorner": {
-                              "$className": "UICorner",
-                              "$properties": {
-                                "CornerRadius": { "UDim": [1, 0] }
-                              }
-                            },
-                            "Fill": {
-                              "$className": "Frame",
-                              "$properties": {
-                                "Name": "Fill",
-                                "BackgroundColor3": { "Color3": [1, 0.768627, 0.431373] },
-                                "BackgroundTransparency": 0.15,
-                                "BorderSizePixel": 0,
-                                "AnchorPoint": { "Vector2": [0, 1] },
-                                "Position": { "UDim2": [0, 0, 1, 0] },
-                                "Size": { "UDim2": [1, 0, 1, 0] }
-                              },
-                              "$children": {
-                                "UICorner": {
-                                  "$className": "UICorner",
-                                  "$properties": {
-                                    "CornerRadius": { "UDim": [1, 0] }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
                         "KeyLabel": {
                           "$className": "TextLabel",
                           "$properties": {
@@ -527,43 +499,6 @@
                             "Color": { "Color3": [0.470588, 0.784314, 1] },
                             "Transparency": 0.2,
                             "ApplyStrokeMode": "Border"
-                          }
-                        },
-                        "Mask": {
-                          "$className": "Frame",
-                          "$properties": {
-                            "Name": "Mask",
-                            "BackgroundTransparency": 1,
-                            "Size": { "UDim2": [1, 0, 1, 0] },
-                            "ClipsDescendants": true
-                          },
-                          "$children": {
-                            "UICorner": {
-                              "$className": "UICorner",
-                              "$properties": {
-                                "CornerRadius": { "UDim": [1, 0] }
-                              }
-                            },
-                            "Fill": {
-                              "$className": "Frame",
-                              "$properties": {
-                                "Name": "Fill",
-                                "BackgroundColor3": { "Color3": [0.470588, 0.784314, 1] },
-                                "BackgroundTransparency": 0.15,
-                                "BorderSizePixel": 0,
-                                "AnchorPoint": { "Vector2": [0, 1] },
-                                "Position": { "UDim2": [0, 0, 1, 0] },
-                                "Size": { "UDim2": [1, 0, 1, 0] }
-                              },
-                              "$children": {
-                                "UICorner": {
-                                  "$className": "UICorner",
-                                  "$properties": {
-                                    "CornerRadius": { "UDim": [1, 0] }
-                                  }
-                                }
-                              }
-                            }
                           }
                         },
                         "KeyLabel": {


### PR DESCRIPTION
## Summary
- reorder the XP header so the level label precedes the XP value and clean up the default text formatting
- remove the unused cooldown fill gauges and rely on numeric countdowns with 0.1s precision
- default the skill and dash cooldown labels to 0.0 seconds when ready and keep their styling consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7aa88f5d8833382e67ec71729cb15