### PR TITLE
Fix malformed JSON in XP header layout

### DIFF
--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -204,89 +204,7 @@
                         "Padding": { "UDim": [0, 8] }
                       }
                     },
-                "LevelLabel": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "LevelLabel",
-                    "BackgroundTransparency": 1,
-                    "Font": "GothamBold",
-                    "Text": "Lv1",
-                    "TextSize": 24,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [0, 80, 1, 0] },
-                    "LayoutOrder": 1
-                  }
-                },
-                "XPText": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "XPText",
-                    "BackgroundTransparency": 1,
-                    "Font": "Gotham",
-                    "Text": "XP0",
-                    "TextSize": 18,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [1, -88, 1, 0] },
-                    "LayoutOrder": 2
-                  }
-                }
-                      "$properties": {
-                        "FillDirection": "Horizontal",
-                        "HorizontalAlignment": "Left",
-                        "VerticalAlignment": "Center",
-                        "Padding": { "UDim": [0, 8] }
-                      }
-                    },
-                "LevelLabel": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "LevelLabel",
-                    "BackgroundTransparency": 1,
-                    "Font": "GothamBold",
-                    "Text": "Lv 1",
-                    "TextSize": 24,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [0, 80, 1, 0] },
-                    "LayoutOrder": 1
-                  }
-                },
-                "XPText": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "XPText",
-                    "BackgroundTransparency": 1,
-                    "Font": "Gotham",
-                    "Text": "XP 0",
-                    "TextSize": 18,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [1, -88, 1, 0] },
-                    "LayoutOrder": 2
-                  }
-                }
-                      "$properties": {
-                        "FillDirection": "Horizontal",
-                        "HorizontalAlignment": "Left",
-                        "VerticalAlignment": "Center",
-                        "Padding": { "UDim": [0, 8] }
-                      }
-                    },
-
-                    "XPText": {
-
                     "LevelLabel": {
-
                       "$className": "TextLabel",
                       "$properties": {
                         "Name": "LevelLabel",
@@ -298,11 +216,7 @@
                         "TextStrokeTransparency": 0.6,
                         "TextXAlignment": "Left",
                         "TextYAlignment": "Center",
-
-                        "Size": { "UDim2": [1, -88, 1, 0] },
-
-                        "Size": { "UDim2": [0, 72, 1, 0] },
-
+                        "Size": { "UDim2": [0, 80, 1, 0] },
                         "LayoutOrder": 1
                       }
                     },
@@ -316,13 +230,9 @@
                         "TextSize": 18,
                         "TextColor3": { "Color3": [1, 1, 1] },
                         "TextStrokeTransparency": 0.6,
-                        "TextXAlignment": "Right",
+                        "TextXAlignment": "Left",
                         "TextYAlignment": "Center",
-
-                        "Size": { "UDim2": [0, 80, 1, 0] },
-
-                        "Size": { "UDim2": [1, -80, 1, 0] },
-
+                        "Size": { "UDim2": [1, -88, 1, 0] },
                         "LayoutOrder": 2
                       }
                     }


### PR DESCRIPTION
## Summary
- remove duplicated children entries from the XPHeader section of the HUD JSON
to restore valid structure
- ensure the level and XP labels retain their intended alignment and sizing

## Testing
- jq . src/startergui/SkillSurvivalHUD/init.screen.gui.json

------
https://chatgpt.com/codex/tasks/task_e_68d7c3a60764833394b276d5a286f38f