### PR TITLE
Fix HUDController XP update syntax errors

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -521,20 +521,21 @@ function HUDController:UpdateXP(state)
     local prefix = xpConfig.LabelPrefix or "XP"
     prefix = string.gsub(prefix, "^%s+", "")
     prefix = string.gsub(prefix, "%s+$", "")
+
     local joiner = xpConfig.LabelJoiner
     if joiner == nil then
         joiner = ""
-        joiner = " "
     else
         joiner = tostring(joiner)
     end
+
     local levelJoiner = xpConfig.LevelJoiner
     if levelJoiner == nil then
         levelJoiner = ""
-        levelJoiner = " "
     else
         levelJoiner = tostring(levelJoiner)
     end
+
     local function composeXPText(valueText: string): string
         if prefix ~= "" then
             return prefix .. joiner .. valueText
@@ -547,19 +548,6 @@ function HUDController:UpdateXP(state)
         levelLabel.Text = string.format("Lv%s%d", levelJoiner, math.max(1, math.floor(levelValue + 0.5)))
     else
         levelLabel.Text = string.format("Lv%s1", levelJoiner)
-    local function composeXPText(valueText: string): string
-        if prefix ~= "" then
-            return string.format("%s %s", prefix, valueText)
-        end
-        return valueText
-    end
-    prefix = string.gsub(prefix, "%s+$", "")
-
-    local levelValue = tonumber(state.Level)
-    if levelValue then
-        levelLabel.Text = string.format("Lv%d", math.max(1, math.floor(levelValue + 0.5)))
-    else
-        levelLabel.Text = "Lv1"
     end
 
     local progress = state.XPProgress
@@ -612,25 +600,6 @@ function HUDController:UpdateXP(state)
         xpLabel.Text = composeXPText(string.format("%d", math.floor(totalXP + 0.5)))
     else
         xpLabel.Text = composeXPText("0")
-    elseif ratio > 0 then
-        xpLabel.Text = composeXPText(string.format("%d%%", math.floor(ratio * 100 + 0.5)))
-    elseif typeof(totalXP) == "number" then
-        xpLabel.Text = composeXPText(string.format("%d", math.floor(totalXP + 0.5)))
-    else
-        xpLabel.Text = composeXPText("0")
-    elseif ratio > 0 then
-        xpLabel.Text = composeXPText(string.format("%d%%", math.floor(ratio * 100 + 0.5)))
-    elseif typeof(totalXP) == "number" then
-        xpLabel.Text = composeXPText(string.format("%d", math.floor(totalXP + 0.5)))
-    else
-        xpLabel.Text = composeXPText("0")
-        xpLabel.Text = string.format("%s%d/%d", prefix, math.floor(current + 0.5), math.floor(required + 0.5))
-    elseif ratio > 0 then
-        xpLabel.Text = string.format("%s%d%%", prefix, math.floor(ratio * 100 + 0.5))
-    elseif typeof(totalXP) == "number" then
-        xpLabel.Text = string.format("%s%d", prefix, math.floor(totalXP + 0.5))
-    else
-        xpLabel.Text = string.format("%s0", prefix)
     end
 end
 

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -204,89 +204,7 @@
                         "Padding": { "UDim": [0, 8] }
                       }
                     },
-                "LevelLabel": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "LevelLabel",
-                    "BackgroundTransparency": 1,
-                    "Font": "GothamBold",
-                    "Text": "Lv1",
-                    "TextSize": 24,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [0, 80, 1, 0] },
-                    "LayoutOrder": 1
-                  }
-                },
-                "XPText": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "XPText",
-                    "BackgroundTransparency": 1,
-                    "Font": "Gotham",
-                    "Text": "XP0",
-                    "TextSize": 18,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [1, -88, 1, 0] },
-                    "LayoutOrder": 2
-                  }
-                }
-                      "$properties": {
-                        "FillDirection": "Horizontal",
-                        "HorizontalAlignment": "Left",
-                        "VerticalAlignment": "Center",
-                        "Padding": { "UDim": [0, 8] }
-                      }
-                    },
-                "LevelLabel": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "LevelLabel",
-                    "BackgroundTransparency": 1,
-                    "Font": "GothamBold",
-                    "Text": "Lv 1",
-                    "TextSize": 24,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [0, 80, 1, 0] },
-                    "LayoutOrder": 1
-                  }
-                },
-                "XPText": {
-                  "$className": "TextLabel",
-                  "$properties": {
-                    "Name": "XPText",
-                    "BackgroundTransparency": 1,
-                    "Font": "Gotham",
-                    "Text": "XP 0",
-                    "TextSize": 18,
-                    "TextColor3": { "Color3": [1, 1, 1] },
-                    "TextStrokeTransparency": 0.6,
-                    "TextXAlignment": "Left",
-                    "TextYAlignment": "Center",
-                    "Size": { "UDim2": [1, -88, 1, 0] },
-                    "LayoutOrder": 2
-                  }
-                }
-                      "$properties": {
-                        "FillDirection": "Horizontal",
-                        "HorizontalAlignment": "Left",
-                        "VerticalAlignment": "Center",
-                        "Padding": { "UDim": [0, 8] }
-                      }
-                    },
-
-                    "XPText": {
-
                     "LevelLabel": {
-
                       "$className": "TextLabel",
                       "$properties": {
                         "Name": "LevelLabel",
@@ -298,11 +216,7 @@
                         "TextStrokeTransparency": 0.6,
                         "TextXAlignment": "Left",
                         "TextYAlignment": "Center",
-
-                        "Size": { "UDim2": [1, -88, 1, 0] },
-
-                        "Size": { "UDim2": [0, 72, 1, 0] },
-
+                        "Size": { "UDim2": [0, 80, 1, 0] },
                         "LayoutOrder": 1
                       }
                     },
@@ -316,13 +230,9 @@
                         "TextSize": 18,
                         "TextColor3": { "Color3": [1, 1, 1] },
                         "TextStrokeTransparency": 0.6,
-                        "TextXAlignment": "Right",
+                        "TextXAlignment": "Left",
                         "TextYAlignment": "Center",
-
-                        "Size": { "UDim2": [0, 80, 1, 0] },
-
-                        "Size": { "UDim2": [1, -80, 1, 0] },
-
+                        "Size": { "UDim2": [1, -88, 1, 0] },
                         "LayoutOrder": 2
                       }
                     }


### PR DESCRIPTION
## Summary
- clean up merge-conflict artifacts in the HUDController UpdateXP routine
- restore the intended XP/level label formatting so the HUD loads without syntax errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c3a60764833394b276d5a286f38f