### PR TITLE
Show countdown and reposition cooldown labels

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -197,6 +197,7 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
     local xpFill = xpBar and xpBar:FindFirstChild("Fill")
 
     local alertArea = safeFrame:FindFirstChild("AlertArea")
+    local countdownLabel = alertArea and alertArea:FindFirstChild("CountdownLabel")
     local waveAnnouncement = alertArea and alertArea:FindFirstChild("WaveAnnouncement")
     local messageLabel = alertArea and alertArea:FindFirstChild("MessageLabel")
     local reservedAlert = alertArea and alertArea:FindFirstChild("ReservedAlerts")
@@ -477,6 +478,7 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         DashCooldownLabel = dash and dash.CooldownLabel or nil,
         MessageLabel = messageLabel,
         WaveAnnouncement = waveAnnouncement,
+        CountdownLabel = countdownLabel,
         ReservedAlert = reservedAlert,
         ReservedAlertLabel = reservedLabel,
         XPFill = xpFill,
@@ -532,8 +534,26 @@ function HUDController:Update(state)
     end
     self.Elements.EnemyLabel.Text = string.format("Enemies: %d", enemies)
 
-    if state.Countdown and state.Countdown > 0 then
-        local countdown = math.max(0, state.Countdown)
+    local countdownValue = typeof(state.Countdown) == "number" and state.Countdown or 0
+    local countdownLabel = self.Elements.CountdownLabel
+    local isPreparing = state.State == "Prepare" and countdownValue > 0
+
+    if countdownLabel then
+        countdownLabel.Visible = false
+        countdownLabel.TextTransparency = 1
+        countdownLabel.Text = ""
+    end
+
+    if isPreparing then
+        local displayCountdown = math.max(0, math.floor(countdownValue + 0.5))
+        self.Elements.TimerLabel.Text = string.format("Start in: %ds", displayCountdown)
+        if countdownLabel then
+            countdownLabel.Text = string.format("Wave starts in: %ds", displayCountdown)
+            countdownLabel.Visible = true
+            countdownLabel.TextTransparency = 0
+        end
+    elseif countdownValue and countdownValue > 0 then
+        local countdown = math.max(0, countdownValue)
         local rounded = math.floor((countdown * 10) + 0.5) / 10
         self.Elements.TimerLabel.Text = string.format("Time: %.1fs", rounded)
     elseif state.TimeRemaining and state.TimeRemaining >= 0 then

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -298,6 +298,23 @@
                 "Padding": { "UDim": [0, 8] }
               }
             },
+            "CountdownLabel": {
+              "$className": "TextLabel",
+              "$properties": {
+                "Name": "CountdownLabel",
+                "BackgroundTransparency": 1,
+                "Font": "GothamBold",
+                "Text": "",
+                "TextSize": 20,
+                "TextColor3": { "Color3": [1, 1, 1] },
+                "TextStrokeTransparency": 0.6,
+                "TextXAlignment": "Center",
+                "TextYAlignment": "Center",
+                "TextTransparency": 1,
+                "Size": { "UDim2": [1, 0, 0, 40] },
+                "LayoutOrder": 0
+              }
+            },
             "WaveAnnouncement": {
               "$className": "TextLabel",
               "$properties": {
@@ -449,8 +466,10 @@
                             "TextScaled": true,
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
-                            "AnchorPoint": { "Vector2": [0.5, 0.5] },
-                            "Position": { "UDim2": [0.5, 0, 0.72, 0] }
+                            "AnchorPoint": { "Vector2": [0.5, 1] },
+                            "Position": { "UDim2": [0.5, 0, 0, -4] },
+                            "Size": { "UDim2": [0.9, 0, 0, 26] },
+                            "ZIndex": 2
                           }
                         }
                       }
@@ -527,8 +546,10 @@
                             "TextScaled": true,
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
-                            "AnchorPoint": { "Vector2": [0.5, 0.5] },
-                            "Position": { "UDim2": [0.5, 0, 0.72, 0] }
+                            "AnchorPoint": { "Vector2": [0.5, 1] },
+                            "Position": { "UDim2": [0.5, 0, 0, -4] },
+                            "Size": { "UDim2": [0.9, 0, 0, 26] },
+                            "ZIndex": 2
                           }
                         }
                       }


### PR DESCRIPTION
## Summary
- add a dedicated countdown label in the alert area and wire it to HUD updates
- show "Start in" messaging on the timer panel during the pre-wave countdown
- move skill and dash cooldown numbers above their slots for clearer visibility

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7cc01b3448333abadd72f43eb62a7