### PR TITLE
Fix cooldown labels and XP header layout

### DIFF
--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -214,28 +214,9 @@
                         "TextSize": 24,
                         "TextColor3": { "Color3": [1, 1, 1] },
                         "TextStrokeTransparency": 0.6,
-                        "TextXAlignment": "Right",
-                        "TextYAlignment": "Center",
-                        "Size": { "UDim2": [1, 0, 1, 0] },
-                        "LayoutOrder": 1
-                      }
-                        "Size": { "UDim2": [0, 80, 1, 0] },
-                        "LayoutOrder": 2
-                      }
-                    },
-                    "XPText": {
-                      "$className": "TextLabel",
-                      "$properties": {
-                        "Name": "XPText",
-                        "BackgroundTransparency": 1,
-                        "Font": "Gotham",
-                        "Text": "XP0",
-                        "TextSize": 18,
-                        "TextColor3": { "Color3": [1, 1, 1] },
-                        "TextStrokeTransparency": 0.6,
                         "TextXAlignment": "Left",
                         "TextYAlignment": "Center",
-                        "Size": { "UDim2": [1, -88, 1, 0] },
+                        "Size": { "UDim2": [0, 80, 1, 0] },
                         "LayoutOrder": 1
                       }
                     }
@@ -484,10 +465,9 @@
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
                             "AnchorPoint": { "Vector2": [0.5, 1] },
-                            "Position": { "UDim2": [0.5, 0, 0, -4] },
+                            "Position": { "UDim2": [0.5, 0, 1, -4] },
                             "Size": { "UDim2": [0.9, 0, 0, 26] },
                             "ZIndex": 3
-                            "ZIndex": 2
                           }
                         }
                       }
@@ -579,10 +559,9 @@
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
                             "AnchorPoint": { "Vector2": [0.5, 1] },
-                            "Position": { "UDim2": [0.5, 0, 0, -4] },
+                            "Position": { "UDim2": [0.5, 0, 1, -4] },
                             "Size": { "UDim2": [0.9, 0, 0, 26] },
                             "ZIndex": 3
-                            "ZIndex": 2
                           }
                         }
                       }


### PR DESCRIPTION
## Summary
- remove the XP text label from the XP header and keep the level label aligned to the left edge
- reposition both cooldown labels so their text stays visible inside the gauge overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e01613ac83338a641e1c38ad0c9b