### PR TITLE
Fix HUD screen detection and gauge backgrounds

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -85,11 +85,18 @@ function HUDController:EnsureInterface(playerGui: PlayerGui?)
     end
 
     local screen = playerGui:FindFirstChild("SkillSurvivalHUD")
-    if not screen then
-        screen = playerGui:WaitForChild("SkillSurvivalHUD", 5)
+    if screen and not screen:IsA("ScreenGui") then
+        screen = screen:FindFirstChildWhichIsA("ScreenGui")
     end
 
     if not screen then
+        screen = playerGui:WaitForChild("SkillSurvivalHUD", 5)
+        if screen and not screen:IsA("ScreenGui") then
+            screen = screen:FindFirstChildWhichIsA("ScreenGui")
+        end
+    end
+
+    if not screen or not screen:IsA("ScreenGui") then
         warn("HUDController: SkillSurvivalHUD missing from PlayerGui")
         return nil
     end
@@ -337,7 +344,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
             else
                 levelLabel.Size = UDim2.new(1, 0, 1, 0)
             end
-            levelLabel.Size = UDim2.new(0, levelWidth, 1, 0)
         end
         if xpBar then
             xpBar.BackgroundColor3 = uiConfig.XP and uiConfig.XP.BackgroundColor or panelBackground
@@ -410,7 +416,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         skill.Container.Size = UDim2.new(0, skillSlotSize, 0, skillSlotSize)
         skill.Gauge.BackgroundColor3 = abilityConfig.SkillBackgroundColor or Color3.fromRGB(18, 24, 32)
         skill.Gauge.BackgroundTransparency = abilityConfig.SkillBackgroundTransparency or 0.2
-        skill.Gauge.BackgroundTransparency = abilityConfig.SkillBackgroundTransparency or 1
         local skillStroke = skill.Gauge:FindFirstChildWhichIsA("UIStroke")
         if skillStroke then
             skillStroke.Color = abilityConfig.SkillStrokeColor or Color3.fromRGB(255, 196, 110)
@@ -438,7 +443,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         dash.Container.Size = UDim2.new(0, dashSize, 0, dashSize)
         dash.Gauge.BackgroundColor3 = dashConfig.BackgroundColor or Color3.fromRGB(18, 24, 32)
         dash.Gauge.BackgroundTransparency = dashConfig.BackgroundTransparency or 0.2
-        dash.Gauge.BackgroundTransparency = dashConfig.BackgroundTransparency or 1
         local dashStroke = dash.Gauge:FindFirstChildWhichIsA("UIStroke")
         if dashStroke then
             dashStroke.Color = dashConfig.StrokeColor or Color3.fromRGB(120, 200, 255)

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -214,28 +214,9 @@
                         "TextSize": 24,
                         "TextColor3": { "Color3": [1, 1, 1] },
                         "TextStrokeTransparency": 0.6,
-                        "TextXAlignment": "Right",
-                        "TextYAlignment": "Center",
-                        "Size": { "UDim2": [1, 0, 1, 0] },
-                        "LayoutOrder": 1
-                      }
-                        "Size": { "UDim2": [0, 80, 1, 0] },
-                        "LayoutOrder": 2
-                      }
-                    },
-                    "XPText": {
-                      "$className": "TextLabel",
-                      "$properties": {
-                        "Name": "XPText",
-                        "BackgroundTransparency": 1,
-                        "Font": "Gotham",
-                        "Text": "XP0",
-                        "TextSize": 18,
-                        "TextColor3": { "Color3": [1, 1, 1] },
-                        "TextStrokeTransparency": 0.6,
                         "TextXAlignment": "Left",
                         "TextYAlignment": "Center",
-                        "Size": { "UDim2": [1, -88, 1, 0] },
+                        "Size": { "UDim2": [0, 80, 1, 0] },
                         "LayoutOrder": 1
                       }
                     }
@@ -424,7 +405,6 @@
                         "Name": "Gauge",
                         "BackgroundColor3": { "Color3": [0.070588, 0.094117, 0.12549] },
                         "BackgroundTransparency": 0.2,
-                        "BackgroundTransparency": 1,
                         "BorderSizePixel": 0,
                         "ClipsDescendants": true,
                         "Size": { "UDim2": [1, 0, 1, 0] }
@@ -484,10 +464,9 @@
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
                             "AnchorPoint": { "Vector2": [0.5, 1] },
-                            "Position": { "UDim2": [0.5, 0, 0, -4] },
+                            "Position": { "UDim2": [0.5, 0, 1, -4] },
                             "Size": { "UDim2": [0.9, 0, 0, 26] },
                             "ZIndex": 3
-                            "ZIndex": 2
                           }
                         }
                       }
@@ -579,10 +558,9 @@
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
                             "AnchorPoint": { "Vector2": [0.5, 1] },
-                            "Position": { "UDim2": [0.5, 0, 0, -4] },
+                            "Position": { "UDim2": [0.5, 0, 1, -4] },
                             "Size": { "UDim2": [0.9, 0, 0, 26] },
                             "ZIndex": 3
-                            "ZIndex": 2
                           }
                         }
                       }


### PR DESCRIPTION
## Summary
- ensure the HUDController resolves a ScreenGui instance before toggling properties so folder-based containers do not trigger errors
- let the level label span the XP header when no XP text is present and keep cooldown slot backgrounds opaque
- remove the stray transparency override from the dash gauge definition so the UI background renders again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e01613ac83338a641e1c38ad0c9b