### PR TITLE
Remove ability key labels and quiet HUD warnings

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -97,7 +97,6 @@ function HUDController:EnsureInterface(playerGui: PlayerGui?)
     end
 
     if not screen or not screen:IsA("ScreenGui") then
-        warn("HUDController: SkillSurvivalHUD missing from PlayerGui")
         return nil
     end
 
@@ -162,7 +161,7 @@ local function resolveCooldownSlot(root: Instance?)
         end
     end
 
-    if not (gauge and cooldownLabel and keyLabel) then
+    if not (gauge and cooldownLabel) then
         return nil
     end
 
@@ -221,7 +220,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
     local dash = resolveCooldownSlot(dashSlot)
 
     if not skill and not dash then
-        warn("HUDController: Ability slots missing or malformed")
         self.Screen = screen
         self.Elements = {}
         if self.InterfaceSignal then
@@ -433,10 +431,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
             skill.CooldownLabel.TextTransparency = 0
             skill.CooldownLabel.Visible = true
         end
-        if skill.KeyLabel then
-            skill.KeyLabel.TextTransparency = 0
-            skill.KeyLabel.Visible = true
-        end
     end
 
     if dash then
@@ -460,10 +454,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
             dash.CooldownLabel.TextTransparency = 0
             dash.CooldownLabel.Visible = true
         end
-        if dash.KeyLabel then
-            dash.KeyLabel.TextTransparency = 0
-            dash.KeyLabel.Visible = true
-        end
     end
 
     self.Screen = screen
@@ -486,15 +476,9 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
     self.DashReadyText = dashReadyText
     self.DashReadyColor = dashConfig.ReadyColor or Color3.fromRGB(180, 255, 205)
 
-    if skill and skill.KeyLabel then
-        skill.KeyLabel.Text = self.SkillDisplayKey
-    end
     if skill and skill.CooldownLabel then
         skill.CooldownLabel.Text = self.SkillReadyText
         skill.CooldownLabel.TextColor3 = self.SkillReadyColor
-    end
-    if dash and dash.KeyLabel then
-        dash.KeyLabel.Text = dashConfig.KeyText or "E"
     end
     if dash and dash.CooldownLabel then
         dash.CooldownLabel.Text = self.DashReadyText
@@ -507,7 +491,6 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         TimerLabel = timerLabel,
         GoldLabel = goldLabel,
         SkillCooldownLabel = skill and skill.CooldownLabel or nil,
-        SkillKeyLabel = skill and skill.KeyLabel or nil,
         SkillCooldownOverlay = skill and skill.Overlay or nil,
         DashCooldownLabel = dash and dash.CooldownLabel or nil,
         DashCooldownOverlay = dash and dash.Overlay or nil,
@@ -771,14 +754,9 @@ end
 
 function HUDController:UpdateSkillCooldowns(skillTable)
     local cooldownLabel = self.Elements.SkillCooldownLabel
-    local keyLabel = self.Elements.SkillKeyLabel
     local overlay = self.Elements.SkillCooldownOverlay
     if not cooldownLabel then
         return
-    end
-
-    if keyLabel then
-        keyLabel.Text = self.SkillDisplayKey or "Q"
     end
 
     local primaryId = self.PrimarySkillId

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -436,22 +436,6 @@
                             "ApplyStrokeMode": "Border"
                           }
                         },
-                        "KeyLabel": {
-                          "$className": "TextLabel",
-                          "$properties": {
-                            "Name": "KeyLabel",
-                            "BackgroundTransparency": 1,
-                            "Font": "GothamBold",
-                            "Text": "Q",
-                            "TextColor3": { "Color3": [1, 1, 1] },
-                            "TextScaled": true,
-                            "TextXAlignment": "Center",
-                            "TextYAlignment": "Center",
-                            "ZIndex": 2,
-                            "AnchorPoint": { "Vector2": [0.5, 0.5] },
-                            "Position": { "UDim2": [0.5, 0, 0.32, 0] }
-                          }
-                        },
                         "CooldownLabel": {
                           "$className": "TextLabel",
                           "$properties": {
@@ -460,7 +444,8 @@
                             "Font": "GothamBold",
                             "Text": "0.0",
                             "TextColor3": { "Color3": [1, 0.921569, 0.784314] },
-                            "TextScaled": true,
+                            "TextScaled": false,
+                            "TextSize": 24,
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
                             "AnchorPoint": { "Vector2": [0.5, 1] },
@@ -498,7 +483,6 @@
                         "Name": "Gauge",
                         "BackgroundColor3": { "Color3": [0.070588, 0.094117, 0.12549] },
                         "BackgroundTransparency": 0.2,
-                        "BackgroundTransparency": 1,
                         "BorderSizePixel": 0,
                         "ClipsDescendants": true,
                         "Size": { "UDim2": [1, 0, 1, 0] }
@@ -530,22 +514,6 @@
                             "ApplyStrokeMode": "Border"
                           }
                         },
-                        "KeyLabel": {
-                          "$className": "TextLabel",
-                          "$properties": {
-                            "Name": "KeyLabel",
-                            "BackgroundTransparency": 1,
-                            "Font": "GothamBold",
-                            "Text": "E",
-                            "TextColor3": { "Color3": [1, 1, 1] },
-                            "TextScaled": true,
-                            "TextXAlignment": "Center",
-                            "TextYAlignment": "Center",
-                            "ZIndex": 2,
-                            "AnchorPoint": { "Vector2": [0.5, 0.5] },
-                            "Position": { "UDim2": [0.5, 0, 0.32, 0] }
-                          }
-                        },
                         "CooldownLabel": {
                           "$className": "TextLabel",
                           "$properties": {
@@ -554,7 +522,8 @@
                             "Font": "GothamBold",
                             "Text": "0.0",
                             "TextColor3": { "Color3": [0.705882, 1, 0.803922] },
-                            "TextScaled": true,
+                            "TextScaled": false,
+                            "TextSize": 24,
                             "TextXAlignment": "Center",
                             "TextYAlignment": "Center",
                             "AnchorPoint": { "Vector2": [0.5, 1] },


### PR DESCRIPTION
## Summary
- remove the skill and dash slot key labels from the HUD and enlarge the cooldown text so it stays legible
- update the HUD controller to tolerate slots without key labels and stop emitting PlayerGui/ability slot warnings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7e6a60c90833392d51549cd632714