### PR TITLE
Set default cooldown ready text

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -451,7 +451,7 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
     self.SkillDisplayKey = abilityConfig.SkillKey or "Q"
     local skillReadyText = abilityConfig.SkillReadyText
     if skillReadyText == nil then
-        skillReadyText = "0.0"
+        skillReadyText = "ready"
     else
         skillReadyText = tostring(skillReadyText)
     end
@@ -460,7 +460,7 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
     self.PrimarySkillId = abilityConfig.PrimarySkillId or "AOE_Blast"
     local dashReadyText = dashConfig.ReadyText
     if dashReadyText == nil then
-        dashReadyText = "0.0"
+        dashReadyText = "ready"
     else
         dashReadyText = tostring(dashReadyText)
     end


### PR DESCRIPTION
## Summary
- update the default ready text for skill and dash cooldown labels to display "ready" when the cooldown completes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f2d82d8483339fdca3d35b74d20b