### PR TITLE
Fix PlayerProgress initialization without Knit.OnStart

### DIFF
--- a/src/client/PlayerProgress.client.lua
+++ b/src/client/PlayerProgress.client.lua
@@ -1,0 +1,461 @@
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local TweenService = game:GetService("TweenService")
+local ContextActionService = game:GetService("ContextActionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Knit = require(ReplicatedStorage.Shared.Knit)
+local Net = require(ReplicatedStorage.Shared.Net)
+local Config = require(ReplicatedStorage.Shared.Config)
+
+local LOCAL_PLAYER = Players.LocalPlayer
+local PLAYER_GUI = LOCAL_PLAYER:WaitForChild("PlayerGui")
+
+local LEVELING = Config.Leveling or {}
+local LEVELING_UI = LEVELING.UI or {}
+local MAX_LEVEL = (LEVELING.MaxLevel and math.floor(LEVELING.MaxLevel)) or 50
+local LERP_SPEED = LEVELING_UI.LerpSpeed or 6
+local FREEZE_FADE = LEVELING_UI.FreezeFade or 0.25
+
+local function waitForController(name: string)
+    while true do
+        local ok, controller = pcall(function()
+            return Knit.GetController(name)
+        end)
+        if ok and controller then
+            return controller
+        end
+        task.wait()
+    end
+end
+
+local function computeXPToNext(level: number): number
+    if level >= MAX_LEVEL then
+        return 0
+    end
+    if typeof(LEVELING.XPToNext) == "function" then
+        local ok, value = pcall(LEVELING.XPToNext, level)
+        if ok and typeof(value) == "number" then
+            return math.max(0, math.floor(value))
+        end
+    end
+    local baseXP = LEVELING.BaseXP or 100
+    local growth = LEVELING.Growth or 1.25
+    return math.max(0, math.floor(baseXP * (growth ^ (math.max(1, level) - 1))))
+end
+
+local uiController: any = nil
+local hudReady = false
+local pushHUDUpdate
+local function markHUDReady()
+    if hudReady then
+        return
+    end
+    hudReady = true
+    if pushHUDUpdate then
+        pushHUDUpdate()
+    end
+end
+
+local levelUpGui = PLAYER_GUI:WaitForChild("LevelUpModal", 5)
+if not levelUpGui then
+    levelUpGui = Instance.new("ScreenGui")
+    levelUpGui.Name = "LevelUpModal"
+    levelUpGui.ResetOnSpawn = false
+    levelUpGui.IgnoreGuiInset = true
+    levelUpGui.DisplayOrder = 100
+    levelUpGui.Enabled = false
+    levelUpGui.Parent = PLAYER_GUI
+end
+
+local freezeOverlay = levelUpGui:FindFirstChild("FreezeOverlay")
+local rootFrame = levelUpGui:FindFirstChild("Root")
+local confirmBlocker = levelUpGui:FindFirstChild("ConfirmBlocker")
+local optionsFrame = rootFrame and rootFrame:FindFirstChild("Options")
+
+local optionButtons = {}
+if optionsFrame then
+    for _, child in ipairs(optionsFrame:GetChildren()) do
+        if child:IsA("TextButton") then
+            table.insert(optionButtons, child)
+        end
+    end
+    table.sort(optionButtons, function(a, b)
+        return a.Name < b.Name
+    end)
+end
+
+local xpState = {
+    level = 1,
+    xp = 0,
+    xpToNext = computeXPToNext(1),
+    currentRatio = 0,
+    targetRatio = 0,
+}
+
+local worldFrozen = false
+local modalActive = false
+local choiceSubmitted = false
+local activeChoices = nil
+local overlayTween: Tween? = nil
+local freezeBlockBound = false
+
+pushHUDUpdate = function()
+    if not uiController or not hudReady then
+        return
+    end
+
+    local progress = {
+        Ratio = math.clamp(xpState.currentRatio, 0, 1),
+        Current = xpState.xp,
+        Required = xpState.xpToNext,
+    }
+
+    uiController.State.Level = xpState.level
+    uiController.State.XP = xpState.xp
+    uiController.State.XPProgress = progress
+    uiController:WithHUD("UpdateXP", {
+        Level = xpState.level,
+        XP = xpState.xp,
+        XPProgress = progress,
+    })
+end
+
+task.spawn(function()
+    uiController = waitForController("UIController")
+    local hudController = waitForController("HUDController")
+
+    if hudController and typeof(hudController.OnInterfaceReady) == "function" then
+        hudController:OnInterfaceReady(function()
+            markHUDReady()
+        end)
+    end
+
+    if hudController and hudController.Screen then
+        markHUDReady()
+    elseif not hudController then
+        markHUDReady()
+    end
+end)
+
+local function setTargetFromXP(xp: number, xpToNext: number)
+    xpToNext = math.max(0, xpToNext or 0)
+    xp = math.max(0, xp or 0)
+    xpState.xp = xp
+    xpState.xpToNext = xpToNext
+    if xpToNext > 0 then
+        xpState.targetRatio = math.clamp(xp / xpToNext, 0, 1)
+    else
+        xpState.targetRatio = 1
+    end
+end
+
+local function applyLevel(level: number, xp: number, xpToNext: number)
+    xpState.level = math.max(1, math.floor(level or 1))
+    setTargetFromXP(xp, xpToNext)
+end
+
+local function setInputBlocked(enabled: boolean)
+    if enabled and not freezeBlockBound then
+        local function sink()
+            return Enum.ContextActionResult.Sink
+        end
+        ContextActionService:BindActionAtPriority(
+            "SS_LevelUpFreeze",
+            sink,
+            false,
+            Enum.ContextActionPriority.High.Value,
+            Enum.KeyCode.W,
+            Enum.KeyCode.A,
+            Enum.KeyCode.S,
+            Enum.KeyCode.D,
+            Enum.KeyCode.Q,
+            Enum.KeyCode.E,
+            Enum.KeyCode.Space,
+            Enum.UserInputType.MouseButton1,
+            Enum.UserInputType.MouseButton2,
+            Enum.UserInputType.Touch
+        )
+        freezeBlockBound = true
+    elseif not enabled and freezeBlockBound then
+        ContextActionService:UnbindAction("SS_LevelUpFreeze")
+        freezeBlockBound = false
+    end
+end
+
+local function tweenOverlay(enabled: boolean)
+    if not freezeOverlay then
+        return
+    end
+
+    if overlayTween then
+        overlayTween:Cancel()
+        overlayTween = nil
+    end
+
+    local goal = {BackgroundTransparency = enabled and 0.35 or 1}
+    overlayTween = TweenService:Create(
+        freezeOverlay,
+        TweenInfo.new(FREEZE_FADE, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+        goal
+    )
+
+    overlayTween.Completed:Connect(function()
+        if not enabled and not modalActive then
+            levelUpGui.Enabled = false
+            if rootFrame then
+                rootFrame.Visible = false
+            end
+        end
+    end)
+
+    overlayTween:Play()
+end
+
+local function resetChoices()
+    activeChoices = nil
+    choiceSubmitted = false
+    if not optionsFrame then
+        return
+    end
+
+    for _, button in ipairs(optionButtons) do
+        button.AutoButtonColor = false
+        button.Active = false
+        button.Selectable = false
+        button.Visible = true
+        local stroke = button:FindFirstChildWhichIsA("UIStroke")
+        if stroke then
+            stroke.Transparency = 0.2
+        end
+        local choiceId = button:FindFirstChild("ChoiceId")
+        if choiceId and choiceId:IsA("StringValue") then
+            choiceId.Value = ""
+        end
+        local nameLabel = button:FindFirstChild("Name")
+        if nameLabel and nameLabel:IsA("TextLabel") then
+            nameLabel.Text = "Loading..."
+        end
+        local descLabel = button:FindFirstChild("Desc")
+        if descLabel and descLabel:IsA("TextLabel") then
+            descLabel.Text = ""
+        end
+    end
+end
+
+local function populateChoices(choices)
+    activeChoices = choices
+    if not choices then
+        for _, button in ipairs(optionButtons) do
+            button.AutoButtonColor = false
+            button.Active = false
+            local nameLabel = button:FindFirstChild("Name")
+            if nameLabel and nameLabel:IsA("TextLabel") then
+                nameLabel.Text = "No Options"
+            end
+            local descLabel = button:FindFirstChild("Desc")
+            if descLabel and descLabel:IsA("TextLabel") then
+                descLabel.Text = "Please wait for the server."
+            end
+        end
+        return
+    end
+
+    for index, button in ipairs(optionButtons) do
+        local info = choices[index]
+        local choiceId = button:FindFirstChild("ChoiceId")
+        if info and typeof(info) == "table" then
+            button.AutoButtonColor = true
+            button.Active = true
+            button.Selectable = true
+            local nameLabel = button:FindFirstChild("Name")
+            local descLabel = button:FindFirstChild("Desc")
+            if nameLabel and nameLabel:IsA("TextLabel") then
+                nameLabel.Text = tostring(info.name or info.id or "Unknown")
+            end
+            if descLabel and descLabel:IsA("TextLabel") then
+                descLabel.Text = tostring(info.desc or "")
+            end
+            if choiceId and choiceId:IsA("StringValue") then
+                choiceId.Value = tostring(info.id or "")
+            end
+        else
+            button.AutoButtonColor = false
+            button.Active = false
+            button.Selectable = false
+            if choiceId and choiceId:IsA("StringValue") then
+                choiceId.Value = ""
+            end
+            local nameLabel = button:FindFirstChild("Name")
+            if nameLabel and nameLabel:IsA("TextLabel") then
+                nameLabel.Text = "Unavailable"
+            end
+            local descLabel = button:FindFirstChild("Desc")
+            if descLabel and descLabel:IsA("TextLabel") then
+                descLabel.Text = ""
+            end
+        end
+    end
+end
+
+local function requestChoices()
+    local remote = Net:GetFunction("GetLevelUpChoices")
+    local success, payload = pcall(function()
+        return remote:InvokeServer()
+    end)
+    if not success then
+        warn("PlayerProgress: failed to fetch level-up choices", payload)
+        populateChoices(nil)
+        return
+    end
+
+    if typeof(payload) ~= "table" then
+        populateChoices(nil)
+        return
+    end
+
+    if not modalActive then
+        return
+    end
+
+    populateChoices(payload.Choices)
+end
+
+local function onOptionClicked(button: TextButton)
+    if choiceSubmitted or not modalActive then
+        return
+    end
+
+    local choiceId = ""
+    local choiceValue = button:FindFirstChild("ChoiceId")
+    if choiceValue and choiceValue:IsA("StringValue") then
+        choiceId = choiceValue.Value
+    end
+    if choiceId == "" then
+        return
+    end
+
+    choiceSubmitted = true
+    for _, option in ipairs(optionButtons) do
+        option.AutoButtonColor = false
+        option.Active = false
+        option.Selectable = false
+        local stroke = option:FindFirstChildWhichIsA("UIStroke")
+        if stroke then
+            stroke.Transparency = option == button and 0 or 0.6
+        end
+    end
+
+    Net:GetEvent("CommitLevelUpChoice"):FireServer(choiceId)
+end
+
+for _, button in ipairs(optionButtons) do
+    button.MouseButton1Click:Connect(function()
+        onOptionClicked(button)
+    end)
+end
+
+if confirmBlocker and confirmBlocker:IsA("GuiButton") then
+    confirmBlocker.AutoButtonColor = false
+    confirmBlocker.MouseButton1Click:Connect(function()
+        -- intentional no-op to block dismiss
+    end)
+end
+
+local function playLevelUpAnimation(newLevel: number, carriedXP: number)
+    carriedXP = carriedXP or 0
+    local previousGoal = xpState.xpToNext > 0 and xpState.xpToNext or computeXPToNext(math.max(1, newLevel - 1))
+    xpState.targetRatio = 1
+    xpState.xp = previousGoal
+    xpState.xpToNext = previousGoal
+
+    task.spawn(function()
+        while math.abs(xpState.currentRatio - 1) > 0.01 do
+            RunService.RenderStepped:Wait()
+        end
+
+        local nextGoal = computeXPToNext(newLevel)
+        xpState.level = math.clamp(newLevel, 1, MAX_LEVEL)
+        xpState.currentRatio = 0
+        xpState.xpToNext = nextGoal
+        xpState.xp = math.clamp(carriedXP, 0, nextGoal > 0 and nextGoal or carriedXP)
+        if nextGoal > 0 then
+            xpState.targetRatio = math.clamp(xpState.xp / nextGoal, 0, 1)
+        else
+            xpState.targetRatio = 1
+        end
+        pushHUDUpdate()
+    end)
+end
+
+local progressFunction = Net:GetFunction("GetProgress")
+local xpChangedEvent = Net:GetEvent("XPChanged")
+local levelUpEvent = Net:GetEvent("LevelUp")
+local freezeEvent = Net:GetEvent("SetWorldFreeze")
+
+local success, initial = pcall(function()
+    return progressFunction:InvokeServer()
+end)
+if success and typeof(initial) == "table" then
+    local level = initial.Level or initial.level or 1
+    local xp = initial.XP or initial.xp or 0
+    local xpToNext = initial.XPToNext or initial.xpToNext or computeXPToNext(level)
+    xpState.currentRatio = xpToNext > 0 and math.clamp(xp / xpToNext, 0, 1) or 1
+    applyLevel(level, xp, xpToNext)
+    pushHUDUpdate()
+else
+    warn("PlayerProgress: failed to load initial progress", initial)
+end
+
+xpChangedEvent.OnClientEvent:Connect(function(player, xp, xpToNext)
+    if player ~= LOCAL_PLAYER then
+        return
+    end
+
+    setTargetFromXP(xp, xpToNext)
+    pushHUDUpdate()
+end)
+
+levelUpEvent.OnClientEvent:Connect(function(player, newLevel, carriedXP)
+    if player ~= LOCAL_PLAYER then
+        return
+    end
+
+    modalActive = true
+    levelUpGui.Enabled = true
+    if rootFrame then
+        rootFrame.Visible = true
+    end
+    setInputBlocked(true)
+    tweenOverlay(true)
+    resetChoices()
+    task.spawn(requestChoices)
+    playLevelUpAnimation(newLevel, carriedXP)
+end)
+
+freezeEvent.OnClientEvent:Connect(function(enabled)
+    worldFrozen = not not enabled
+    setInputBlocked(worldFrozen)
+    if worldFrozen then
+        levelUpGui.Enabled = true
+        tweenOverlay(true)
+    else
+        tweenOverlay(false)
+        modalActive = false
+        if rootFrame then
+            rootFrame.Visible = false
+        end
+        resetChoices()
+    end
+end)
+
+RunService.RenderStepped:Connect(function(dt)
+    local diff = xpState.targetRatio - xpState.currentRatio
+    if math.abs(diff) > 0.0005 then
+        local step = math.clamp(dt * LERP_SPEED, 0, 1)
+        xpState.currentRatio += diff * step
+    else
+        xpState.currentRatio = xpState.targetRatio
+    end
+    pushHUDUpdate()
+end)

--- a/src/server/Services/BossService.lua
+++ b/src/server/Services/BossService.lua
@@ -16,11 +16,13 @@ function BossService:KnitInit()
     self.EnrageTriggered = Knit.Util.Signal.new()
     self.SessionActive = false
     self.MatchStartTime = 0
+    self.MatchStartWorldTime = 0
     self._bossTriggered = false
     self._enrageTriggered = false
 end
 
 function BossService:KnitStart()
+    self.PlayerProgressService = Knit.GetService("PlayerProgressService")
     RunService.Heartbeat:Connect(function()
         self:_onHeartbeat()
     end)
@@ -36,12 +38,18 @@ function BossService:_onHeartbeat()
         return
     end
 
-    local startTime = self.MatchStartTime
+    if self.PlayerProgressService and self.PlayerProgressService:IsWorldFrozen() then
+        -- TODO: Defer boss ability timers while the world is frozen.
+        return
+    end
+
+    local startTime = self.MatchStartWorldTime
     if typeof(startTime) ~= "number" or startTime <= 0 then
         return
     end
 
-    local elapsed = time() - startTime
+    local worldTime = self:GetWorldTime()
+    local elapsed = math.max(0, worldTime - startTime)
     local bossTime, enrageTime = self:GetConfiguredTimings()
 
     if not self._bossTriggered and elapsed >= bossTime then
@@ -66,13 +74,22 @@ end
 
 function BossService:StartSession(startTime: number?)
     self.SessionActive = true
-    self.MatchStartTime = startTime or time()
+    local serverNow = time()
+    self.MatchStartTime = startTime or serverNow
+    local worldNow = self:GetWorldTime()
+    if typeof(self.MatchStartTime) == "number" then
+        local delta = serverNow - self.MatchStartTime
+        self.MatchStartWorldTime = worldNow - delta
+    else
+        self.MatchStartWorldTime = worldNow
+    end
     self:_reset()
 end
 
 function BossService:StopSession()
     self.SessionActive = false
     self.MatchStartTime = 0
+    self.MatchStartWorldTime = 0
     self:_reset()
 end
 
@@ -84,6 +101,19 @@ end
 function BossService:TriggerEnrage(elapsed: number)
     self.EnrageTriggered:Fire(elapsed)
     Net:FireAll("BossEnraged")
+end
+
+function BossService:GetWorldTime(): number
+    local service = self.PlayerProgressService
+    if service and typeof(service.GetWorldTime) == "function" then
+        local ok, result = pcall(function()
+            return service:GetWorldTime()
+        end)
+        if ok and typeof(result) == "number" then
+            return result
+        end
+    end
+    return time()
 end
 
 return BossService

--- a/src/server/Services/DashService.lua
+++ b/src/server/Services/DashService.lua
@@ -73,6 +73,7 @@ function DashService:KnitStart()
 
 
     self.EnemyService = Knit.GetService("EnemyService")
+    self.PlayerProgressService = Knit.GetService("PlayerProgressService")
 
     Net:GetEvent("DashRequest").OnServerEvent:Connect(function(player, direction)
         self:HandleDashRequest(player, direction)
@@ -302,6 +303,11 @@ function DashService:ScheduleIFrameClear(character: Model, duration: number)
 end
 
 function DashService:UpdateDashes()
+    if self.PlayerProgressService and self.PlayerProgressService:IsWorldFrozen() then
+        -- TODO: Pause dash progression entirely while world freeze is active.
+        return
+    end
+
     if next(self.ActiveDashes) == nil then
         return
     end

--- a/src/server/Services/PlayerProgressService.lua
+++ b/src/server/Services/PlayerProgressService.lua
@@ -1,0 +1,401 @@
+local Players = game:GetService("Players")
+local HttpService = game:GetService("HttpService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Knit = require(ReplicatedStorage.Shared.Knit)
+local Config = require(ReplicatedStorage.Shared.Config)
+local Net = require(ReplicatedStorage.Shared.Net)
+
+local PlayerProgressService = Knit.CreateService({
+    Name = "PlayerProgressService",
+    Client = {},
+})
+
+local DEFAULT_CHOICES = {
+    {
+        id = "atk_+10",
+        name = "Power Module",
+        desc = "+10% Attack",
+        kind = "stat",
+        value = 0.10,
+    },
+    {
+        id = "hp_+15",
+        name = "Vital Core",
+        desc = "+15% Max HP",
+        kind = "stat",
+        value = 0.15,
+    },
+    {
+        id = "dash+1",
+        name = "Swift Step",
+        desc = "+1 Dash Charge",
+        kind = "perk",
+        value = 1,
+    },
+    {
+        id = "ult_cd-10",
+        name = "Focus Coil",
+        desc = "-10% Ultimate Cooldown",
+        kind = "perk",
+        value = 0.10,
+    },
+    {
+        id = "resurge",
+        name = "Resurge",
+        desc = "Heal 35% HP instantly",
+        kind = "instant",
+        value = 0.35,
+    },
+}
+
+function PlayerProgressService:KnitInit()
+    self.Profiles = {} :: {[Player]: {
+        level: number,
+        xp: number,
+        xpToNext: number,
+        isFrozen: boolean,
+        queue: { {level: number, carriedXP: number, xpToNext: number} },
+        activeLevelUp: {
+            level: number,
+            carriedXP: number,
+            xpToNext: number,
+            token: string,
+            committed: boolean,
+            choices: { [number]: { id: string, name: string, desc: string, kind: string, value: any } }?,
+        }?,
+    }}
+    self.ActiveFreezes = 0
+    self.WorldFrozen = false
+    self.WorldFreezeStartedAt = nil
+    self.TotalFreezeDuration = 0
+    self.WorldFreezeChanged = Knit.Util.Signal.new()
+    self.Random = Random.new()
+    self.LevelingConfig = Config.Leveling or {}
+end
+
+function PlayerProgressService:KnitStart()
+    Players.PlayerAdded:Connect(function(player)
+        self:CreateProfile(player)
+    end)
+
+    Players.PlayerRemoving:Connect(function(player)
+        self:RemoveProfile(player)
+    end)
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        self:CreateProfile(player)
+    end
+
+    Net:GetFunction("GetProgress").OnServerInvoke = function(player)
+        local profile = self:CreateProfile(player)
+        return {
+            Level = profile.level,
+            XP = profile.xp,
+            XPToNext = profile.xpToNext,
+            MaxLevel = self:GetMaxLevel(),
+        }
+    end
+
+    Net:GetFunction("GetLevelUpChoices").OnServerInvoke = function(player)
+        return self:OnGetLevelUpChoices(player)
+    end
+
+    Net:GetEvent("CommitLevelUpChoice").OnServerEvent:Connect(function(player, choiceId)
+        self:OnCommitLevelUpChoice(player, choiceId)
+    end)
+end
+
+function PlayerProgressService:GetMaxLevel(): number
+    local maxLevel = self.LevelingConfig and self.LevelingConfig.MaxLevel
+    if typeof(maxLevel) == "number" and maxLevel > 0 then
+        return math.floor(maxLevel)
+    end
+    return 50
+end
+
+function PlayerProgressService:ComputeXPToNext(level: number): number
+    local leveling = self.LevelingConfig
+    if leveling and typeof(leveling.XPToNext) == "function" then
+        local value = leveling.XPToNext(level)
+        if typeof(value) == "number" then
+            return math.max(0, math.floor(value))
+        end
+    end
+    local baseXP = (leveling and leveling.BaseXP) or 100
+    local growth = (leveling and leveling.Growth) or 1.25
+    return math.max(0, math.floor(baseXP * (growth ^ (math.max(1, math.floor(level)) - 1))))
+end
+
+function PlayerProgressService:CreateProfile(player: Player)
+    local existing = self.Profiles[player]
+    if existing then
+        return existing
+    end
+
+    local profile = {
+        level = 1,
+        xp = 0,
+        xpToNext = self:ComputeXPToNext(1),
+        isFrozen = false,
+        queue = {},
+        activeLevelUp = nil,
+    }
+
+    self.Profiles[player] = profile
+    return profile
+end
+
+function PlayerProgressService:RemoveProfile(player: Player)
+    local profile = self.Profiles[player]
+    if not profile then
+        return
+    end
+
+    if profile.isFrozen then
+        profile.isFrozen = false
+        profile.activeLevelUp = nil
+        self.ActiveFreezes = math.max(0, self.ActiveFreezes - 1)
+        if self.ActiveFreezes == 0 then
+            self:SetWorldFreeze(false)
+        end
+    end
+
+    self.Profiles[player] = nil
+end
+
+function PlayerProgressService:IsWorldFrozen(): boolean
+    return self.WorldFrozen
+end
+
+function PlayerProgressService:SetWorldFreeze(enabled: boolean)
+    if enabled then
+        if not self.WorldFrozen then
+            self.WorldFrozen = true
+            self.WorldFreezeStartedAt = time()
+            Net:FireAll("SetWorldFreeze", true)
+            if self.WorldFreezeChanged then
+                self.WorldFreezeChanged:Fire(true, 0)
+            end
+        end
+    else
+        if self.WorldFrozen then
+            local duration = 0
+            if self.WorldFreezeStartedAt then
+                duration = math.max(0, time() - self.WorldFreezeStartedAt)
+                self.TotalFreezeDuration += duration
+            end
+            self.WorldFrozen = false
+            self.WorldFreezeStartedAt = nil
+            Net:FireAll("SetWorldFreeze", false)
+            if self.WorldFreezeChanged then
+                self.WorldFreezeChanged:Fire(false, duration)
+            end
+        end
+    end
+end
+
+function PlayerProgressService:GetProfile(player: Player)
+    return self.Profiles[player]
+end
+
+function PlayerProgressService:GetTotalFrozenTime(): number
+    local total = self.TotalFreezeDuration or 0
+    if self.WorldFrozen and self.WorldFreezeStartedAt then
+        total += math.max(0, time() - self.WorldFreezeStartedAt)
+    end
+    return total
+end
+
+function PlayerProgressService:GetWorldTime(): number
+    local total = self:GetTotalFrozenTime()
+    return time() - total
+end
+
+function PlayerProgressService:OnWorldFreezeChanged(callback)
+    if not self.WorldFreezeChanged or typeof(callback) ~= "function" then
+        return nil
+    end
+    return self.WorldFreezeChanged:Connect(callback)
+end
+
+function PlayerProgressService:AddXP(player: Player, amount: number, reason: string?)
+    local profile = self:GetProfile(player)
+    if not profile then
+        return
+    end
+
+    if typeof(amount) ~= "number" or not amount or amount <= 0 or amount ~= amount then
+        return
+    end
+
+    local maxLevel = self:GetMaxLevel()
+    if profile.level >= maxLevel then
+        profile.level = maxLevel
+        profile.xp = 0
+        profile.xpToNext = 0
+        self:FireXPChanged(player, profile)
+        return
+    end
+
+    profile.xp += amount
+
+    local leveled = false
+    while profile.level < maxLevel and profile.xpToNext > 0 and profile.xp >= profile.xpToNext do
+        local carried = profile.xp - profile.xpToNext
+        profile.level += 1
+        profile.xp = math.max(0, carried)
+        profile.xpToNext = self:ComputeXPToNext(profile.level)
+
+        profile.queue[#profile.queue + 1] = {
+            level = profile.level,
+            carriedXP = profile.xp,
+            xpToNext = profile.xpToNext,
+        }
+
+        leveled = true
+
+        if profile.level >= maxLevel then
+            profile.level = maxLevel
+            profile.xp = 0
+            profile.xpToNext = 0
+            profile.queue = {}
+            break
+        end
+    end
+
+    if leveled then
+        self:ProcessQueue(player, profile)
+    elseif not profile.isFrozen then
+        self:FireXPChanged(player, profile)
+    end
+end
+
+function PlayerProgressService:ProcessQueue(player: Player, profile)
+    if profile.isFrozen then
+        return
+    end
+
+    local nextEntry = profile.queue[1]
+    if not nextEntry then
+        return
+    end
+
+    self:BeginLevelUpFreeze(player, profile, nextEntry)
+end
+
+function PlayerProgressService:BeginLevelUpFreeze(player: Player, profile, entry)
+    profile.isFrozen = true
+    self.ActiveFreezes += 1
+    if self.ActiveFreezes == 1 then
+        self:SetWorldFreeze(true)
+    end
+
+    profile.activeLevelUp = {
+        level = entry.level,
+        carriedXP = entry.carriedXP,
+        xpToNext = entry.xpToNext,
+        token = HttpService:GenerateGUID(false),
+        committed = false,
+        choices = nil,
+    }
+
+    Net:FireAll("LevelUp", player, entry.level, entry.carriedXP)
+end
+
+function PlayerProgressService:GenerateChoices(player: Player, profile)
+    local pool = DEFAULT_CHOICES
+    local count = math.min(3, #pool)
+    local used = {}
+    local results = {}
+    for _ = 1, count do
+        local index
+        repeat
+            index = self.Random:NextInteger(1, #pool)
+        until not used[index]
+        used[index] = true
+        local entry = pool[index]
+        results[#results + 1] = table.clone(entry)
+    end
+    return results
+end
+
+function PlayerProgressService:OnGetLevelUpChoices(player: Player)
+    local profile = self:GetProfile(player)
+    if not profile or not profile.isFrozen then
+        return nil
+    end
+
+    local active = profile.activeLevelUp
+    if not active or active.committed then
+        return nil
+    end
+
+    if not active.choices then
+        active.choices = self:GenerateChoices(player, profile)
+    end
+
+    return {
+        Token = active.token,
+        Choices = active.choices,
+    }
+end
+
+function PlayerProgressService:OnCommitLevelUpChoice(player: Player, choiceId: string)
+    local profile = self:GetProfile(player)
+    if not profile or not profile.isFrozen then
+        return
+    end
+
+    local active = profile.activeLevelUp
+    if not active or active.committed then
+        return
+    end
+
+    if typeof(choiceId) ~= "string" or choiceId == "" then
+        return
+    end
+
+    local chosen = nil
+    if active.choices then
+        for _, option in ipairs(active.choices) do
+            if option.id == choiceId then
+                chosen = option
+                break
+            end
+        end
+    end
+
+    if not chosen then
+        return
+    end
+
+    active.committed = true
+    profile.lastChoice = chosen
+
+    -- TODO: integrate stat and perk application once systems are available.
+
+    self:CompleteLevelUp(player, profile)
+end
+
+function PlayerProgressService:CompleteLevelUp(player: Player, profile)
+    if profile.queue[1] then
+        table.remove(profile.queue, 1)
+    end
+
+    profile.activeLevelUp = nil
+    profile.isFrozen = false
+    self.ActiveFreezes = math.max(0, self.ActiveFreezes - 1)
+    if self.ActiveFreezes == 0 then
+        self:SetWorldFreeze(false)
+    end
+
+    self:FireXPChanged(player, profile)
+    self:ProcessQueue(player, profile)
+end
+
+function PlayerProgressService:FireXPChanged(player: Player, profile)
+    Net:FireAll("XPChanged", player, profile.xp, profile.xpToNext)
+end
+
+return PlayerProgressService

--- a/src/server/Services/RewardService.lua
+++ b/src/server/Services/RewardService.lua
@@ -48,6 +48,10 @@ function RewardService:SetupPlayer(player: Player)
     self:PushStats(player)
 end
 
+function RewardService:KnitStart()
+    self.PlayerProgressService = Knit.GetService("PlayerProgressService")
+end
+
 function RewardService:ResetPlayer(player: Player)
     local stats = self.PlayerStats[player]
     if not stats then
@@ -161,6 +165,9 @@ function RewardService:FinalizeMatch(reason: string)
         stats.XP = stats.XP + Config.Rewards.ResultXPBonus
         self.ResultReasons[player] = reason
         self:PushStats(player)
+        if self.PlayerProgressService then
+            self.PlayerProgressService:AddXP(player, Config.Rewards.ResultXPBonus, "Result")
+        end
         if self.DataStore then
             pcall(function()
                 self.DataStore:SetAsync("player_" .. player.UserId, {

--- a/src/shared/Config.lua
+++ b/src/shared/Config.lua
@@ -56,6 +56,33 @@ Config.Rewards = {
     ResultXPBonus = 100,
 }
 
+Config.Leveling = Config.Leveling or {}
+
+local leveling = Config.Leveling
+leveling.BaseXP = leveling.BaseXP or 100
+leveling.Growth = leveling.Growth or 1.25
+leveling.MaxLevel = leveling.MaxLevel or 50
+leveling.XP = leveling.XP or {
+    Kill = 12,
+    Assist = 6,
+    BossKill = 250,
+    Minute = 0,
+}
+
+leveling.UI = leveling.UI or {}
+local levelingUI = leveling.UI
+levelingUI.LerpSpeed = levelingUI.LerpSpeed or 6
+levelingUI.ToastDuration = levelingUI.ToastDuration or 2.0
+levelingUI.FreezeFade = levelingUI.FreezeFade or 0.25
+
+function leveling.XPToNext(level: number): number
+    level = math.max(1, math.floor(level))
+    local base = leveling.BaseXP or 0
+    local growth = leveling.Growth or 1
+    local value = base * (growth ^ (level - 1))
+    return math.floor(value)
+end
+
 Config.Map = {
     FloorSize = Vector3.new(220, 2, 220),
     FloorMaterial = Enum.Material.Slate,

--- a/src/shared/Net.lua
+++ b/src/shared/Net.lua
@@ -37,10 +37,16 @@ Net.Definitions = {
         BossEnraged = "BossEnraged",
         RushWarning = "RushWarning",
         TeammateDown = "TeammateDown",
+        XPChanged = "XPChanged",
+        LevelUp = "LevelUp",
+        CommitLevelUpChoice = "CommitLevelUpChoice",
+        SetWorldFreeze = "SetWorldFreeze",
     },
     Functions = {
         RequestSummary = "RequestSummary",
         RestartMatch = "RestartMatch",
+        GetProgress = "GetProgress",
+        GetLevelUpChoices = "GetLevelUpChoices",
     },
 }
 

--- a/src/startergui/LevelUpModal/init.screen.gui.json
+++ b/src/startergui/LevelUpModal/init.screen.gui.json
@@ -1,0 +1,205 @@
+{
+  "$className": "ScreenGui",
+  "$properties": {
+    "Name": "LevelUpModal",
+    "ResetOnSpawn": false,
+    "IgnoreGuiInset": true,
+    "ZIndexBehavior": "Sibling",
+    "DisplayOrder": 100,
+    "Enabled": false
+  },
+  "$children": {
+    "ConfirmBlocker": {
+      "$className": "TextButton",
+      "$properties": {
+        "Name": "ConfirmBlocker",
+        "BackgroundTransparency": 1,
+        "Size": { "UDim2": [1, 0, 1, 0] },
+        "Text": "",
+        "AutoButtonColor": false,
+        "Selectable": false,
+        "ZIndex": 1
+      }
+    },
+    "FreezeOverlay": {
+      "$className": "Frame",
+      "$properties": {
+        "Name": "FreezeOverlay",
+        "BackgroundColor3": { "Color3": [0, 0, 0] },
+        "BackgroundTransparency": 1,
+        "Size": { "UDim2": [1, 0, 1, 0] },
+        "ZIndex": 2
+      }
+    },
+    "Root": {
+      "$className": "Frame",
+      "$properties": {
+        "Name": "Root",
+        "Active": true,
+        "Modal": true,
+        "BackgroundTransparency": 1,
+        "Size": { "UDim2": [0, 520, 0, 340] },
+        "AnchorPoint": { "Vector2": [0.5, 0.5] },
+        "Position": { "UDim2": [0.5, 0, 0.5, 0] },
+        "Visible": false,
+        "ZIndex": 3
+      },
+      "$children": {
+        "UIPadding": {
+          "$className": "UIPadding",
+          "$properties": {
+            "PaddingTop": { "UDim": [0, 24] },
+            "PaddingBottom": { "UDim": [0, 24] },
+            "PaddingLeft": { "UDim": [0, 24] },
+            "PaddingRight": { "UDim": [0, 24] }
+          }
+        },
+        "UIListLayout": {
+          "$className": "UIListLayout",
+          "$properties": {
+            "FillDirection": "Vertical",
+            "HorizontalAlignment": "Center",
+            "VerticalAlignment": "Center",
+            "Padding": { "UDim": [0, 20] }
+          }
+        },
+        "Title": {
+          "$className": "TextLabel",
+          "$properties": {
+            "Name": "Title",
+            "BackgroundTransparency": 1,
+            "Text": "Choose 1 Upgrade",
+            "Font": "GothamBold",
+            "TextSize": 32,
+            "TextColor3": { "Color3": [1, 1, 1] },
+            "TextStrokeTransparency": 0.6,
+            "Size": { "UDim2": [1, -48, 0, 48] },
+            "ZIndex": 3
+          }
+        },
+        "Options": {
+          "$className": "Frame",
+          "$properties": {
+            "Name": "Options",
+            "BackgroundTransparency": 1,
+            "Size": { "UDim2": [1, 0, 0, 220] },
+            "ZIndex": 3
+          },
+          "$children": {
+            "UIListLayout": {
+              "$className": "UIListLayout",
+              "$properties": {
+                "FillDirection": "Horizontal",
+                "HorizontalAlignment": "Center",
+                "VerticalAlignment": "Center",
+                "Padding": { "UDim": [0, 16] }
+              }
+            },
+            "Option1": {
+              "$className": "TextButton",
+              "$properties": {
+                "Name": "Option1",
+                "BackgroundColor3": { "Color3": [0.113725, 0.14902, 0.2] },
+                "BackgroundTransparency": 0.2,
+                "BorderSizePixel": 0,
+                "AutoButtonColor": true,
+                "Text": "",
+                "Size": { "UDim2": [0, 150, 1, 0] },
+                "ZIndex": 3
+              },
+              "$children": {
+                "UICorner": {
+                  "$className": "UICorner",
+                  "$properties": { "CornerRadius": { "UDim": [0, 12] } }
+                },
+                "UIStroke": {
+                  "$className": "UIStroke",
+                  "$properties": {
+                    "Color": { "Color3": [0.345098, 0.713725, 1] },
+                    "Thickness": 2,
+                    "Transparency": 0.2
+                  }
+                },
+                "UIPadding": {
+                  "$className": "UIPadding",
+                  "$properties": {
+                    "PaddingTop": { "UDim": [0, 12] },
+                    "PaddingBottom": { "UDim": [0, 12] },
+                    "PaddingLeft": { "UDim": [0, 12] },
+                    "PaddingRight": { "UDim": [0, 12] }
+                  }
+                },
+                "UIListLayout": {
+                  "$className": "UIListLayout",
+                  "$properties": {
+                    "FillDirection": "Vertical",
+                    "HorizontalAlignment": "Left",
+                    "VerticalAlignment": "Top",
+                    "Padding": { "UDim": [0, 8] }
+                  }
+                },
+                "Icon": {
+                  "$className": "ImageLabel",
+                  "$properties": {
+                    "Name": "Icon",
+                    "BackgroundTransparency": 1,
+                    "ImageTransparency": 0.1,
+                    "ImageColor3": { "Color3": [0.784314, 0.94902, 1] },
+                    "Size": { "UDim2": [0, 48, 0, 48] },
+                    "ZIndex": 3
+                  }
+                },
+                "Name": {
+                  "$className": "TextLabel",
+                  "$properties": {
+                    "Name": "Name",
+                    "BackgroundTransparency": 1,
+                    "Font": "GothamBold",
+                    "Text": "Option",
+                    "TextSize": 20,
+                    "TextColor3": { "Color3": [1, 1, 1] },
+                    "TextXAlignment": "Left",
+                    "TextWrapped": true,
+                    "Size": { "UDim2": [1, 0, 0, 24] },
+                    "ZIndex": 3
+                  }
+                },
+                "Desc": {
+                  "$className": "TextLabel",
+                  "$properties": {
+                    "Name": "Desc",
+                    "BackgroundTransparency": 1,
+                    "Font": "Gotham",
+                    "Text": "Description",
+                    "TextSize": 16,
+                    "TextColor3": { "Color3": [0.85098, 0.909804, 1] },
+                    "TextXAlignment": "Left",
+                    "TextWrapped": true,
+                    "Size": { "UDim2": [1, 0, 1, -84] },
+                    "ZIndex": 3
+                  }
+                },
+                "ChoiceId": {
+                  "$className": "StringValue",
+                  "$properties": { "Name": "ChoiceId", "Value": "" }
+                }
+              }
+            },
+            "Option2": {
+              "$ref": "Option1",
+              "$properties": {
+                "Name": "Option2"
+              }
+            },
+            "Option3": {
+              "$ref": "Option1",
+              "$properties": {
+                "Name": "Option3"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- wait for the UI and HUD controllers via a safe polling helper instead of calling the missing `Knit.OnStart`
- mark HUD readiness once the interface is available and trigger the XP HUD update when controllers are ready

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e3d7b3808333a429cf927f7b4fa7