### PR TITLE
Fix AOE indicator radius replication

### DIFF
--- a/src/server/Services/CombatService.lua
+++ b/src/server/Services/CombatService.lua
@@ -203,7 +203,7 @@ function CombatService:ExecuteAOEBlast(player: Player, root: BasePart, levelInfo
     Net:FireAll("Combat", {
         Type = "AOE",
         Position = origin,
-        Radius = baseRadius,
+        Radius = radius,
     })
 end
 


### PR DESCRIPTION
## Summary
- send the scaled damage radius to clients so the telegraph ring matches the server blast size

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d93b2764688333ae64f630b5fdab39