### PR TITLE
Add centered pre-game countdown display

### DIFF
--- a/src/client/Controllers/HUDController.lua
+++ b/src/client/Controllers/HUDController.lua
@@ -490,11 +490,21 @@ function HUDController:CaptureInterfaceElements(screen: ScreenGui, abilityConfig
         CountdownLabel = countdownLabel,
         ReservedAlert = reservedAlert,
         ReservedAlertLabel = reservedLabel,
+        AlertArea = alertArea,
         XPFill = xpFill,
         XPTextLabel = xpLabel,
         LevelLabel = levelLabel,
         XPBar = xpBar,
     }
+
+    if alertArea and not self._alertAreaLastState then
+        self.AlertAreaDefault = {
+            AnchorPoint = alertArea.AnchorPoint,
+            Position = alertArea.Position,
+        }
+    elseif not alertArea then
+        self.AlertAreaDefault = nil
+    end
 
     if self.InterfaceSignal then
         self.InterfaceSignal:Fire(screen)
@@ -605,11 +615,17 @@ function HUDController:Update(state)
     self.Elements.EnemyLabel.Text = string.format("Enemies: %d", enemies)
 
     local countdownLabel = self.Elements.CountdownLabel
+    local alertArea = self.Elements.AlertArea
+    local waveAnnouncement = self.Elements.WaveAnnouncement
+    local messageLabel = self.Elements.MessageLabel
+    local reservedAlert = self.Elements.ReservedAlert
     local stateName = state.State
     local countdownValue = tonumber(state.Countdown)
+    local showPrepareCountdown = false
 
     if countdownLabel then
         if stateName == "Prepare" and countdownValue and countdownValue > 0 then
+            showPrepareCountdown = true
             countdownLabel.Visible = true
             countdownLabel.TextTransparency = 0
             countdownLabel.Text = string.format("START IN : %ds", math.ceil(countdownValue))
@@ -617,6 +633,50 @@ function HUDController:Update(state)
             countdownLabel.Visible = false
             countdownLabel.TextTransparency = 1
             countdownLabel.Text = ""
+        end
+    end
+
+    if alertArea then
+        if showPrepareCountdown then
+            if not self._alertAreaLastState then
+                self._alertAreaLastState = {
+                    AnchorPoint = alertArea.AnchorPoint,
+                    Position = alertArea.Position,
+                    WaveVisible = waveAnnouncement and waveAnnouncement.Visible or nil,
+                    MessageVisible = messageLabel and messageLabel.Visible or nil,
+                    ReservedVisible = reservedAlert and reservedAlert.Visible or nil,
+                }
+            end
+            alertArea.AnchorPoint = Vector2.new(0.5, 0.5)
+            alertArea.Position = UDim2.new(0.5, 0, 0.5, 0)
+            if waveAnnouncement then
+                waveAnnouncement.Visible = false
+            end
+            if messageLabel then
+                messageLabel.Visible = false
+            end
+            if reservedAlert then
+                reservedAlert.Visible = false
+            end
+        elseif self._alertAreaLastState then
+            local defaults = self.AlertAreaDefault
+            if defaults then
+                alertArea.AnchorPoint = defaults.AnchorPoint or alertArea.AnchorPoint
+                alertArea.Position = defaults.Position or alertArea.Position
+            else
+                alertArea.AnchorPoint = self._alertAreaLastState.AnchorPoint or alertArea.AnchorPoint
+                alertArea.Position = self._alertAreaLastState.Position or alertArea.Position
+            end
+            if waveAnnouncement and self._alertAreaLastState.WaveVisible ~= nil then
+                waveAnnouncement.Visible = self._alertAreaLastState.WaveVisible
+            end
+            if messageLabel and self._alertAreaLastState.MessageVisible ~= nil then
+                messageLabel.Visible = self._alertAreaLastState.MessageVisible
+            end
+            if reservedAlert and self._alertAreaLastState.ReservedVisible ~= nil then
+                reservedAlert.Visible = self._alertAreaLastState.ReservedVisible
+            end
+            self._alertAreaLastState = nil
         end
     end
 

--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -305,13 +305,13 @@
                 "BackgroundTransparency": 1,
                 "Font": "GothamBold",
                 "Text": "",
-                "TextSize": 48,
+                "TextSize": 64,
                 "TextColor3": { "Color3": [1, 1, 1] },
-                "TextStrokeTransparency": 0.35,
+                "TextStrokeTransparency": 0.25,
                 "TextXAlignment": "Center",
                 "TextYAlignment": "Center",
                 "TextTransparency": 1,
-                "Size": { "UDim2": [1, 0, 0, 80] },
+                "Size": { "UDim2": [1, 0, 0, 96] },
                 "LayoutOrder": 0
               }
             },


### PR DESCRIPTION
## Summary
- expand the AlertArea HUD state tracking so the pre-game countdown text is surfaced with "START IN : Ns" messaging
- center the alert area during the prepare phase and temporarily hide other alerts while the countdown is visible
- increase the countdown label's size and stroke for a more prominent on-screen display before the match starts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d93c4ac8548333bdd500643c9a9b96