### PR TITLE
Adjust pre-game countdown prominence

### DIFF
--- a/src/startergui/SkillSurvivalHUD/init.screen.gui.json
+++ b/src/startergui/SkillSurvivalHUD/init.screen.gui.json
@@ -305,13 +305,13 @@
                 "BackgroundTransparency": 1,
                 "Font": "GothamBold",
                 "Text": "",
-                "TextSize": 48,
+                "TextSize": 92,
                 "TextColor3": { "Color3": [1, 1, 1] },
-                "TextStrokeTransparency": 0.35,
+                "TextStrokeTransparency": 0.18,
                 "TextXAlignment": "Center",
                 "TextYAlignment": "Center",
                 "TextTransparency": 1,
-                "Size": { "UDim2": [1, 0, 0, 80] },
+                "Size": { "UDim2": [1, 0, 0, 128] },
                 "LayoutOrder": 0
               }
             },


### PR DESCRIPTION
## Summary
- expand the AlertArea HUD state tracking so the pre-game countdown text is surfaced with "START IN : Ns" messaging
- center the alert area during the prepare phase and temporarily hide other alerts while the countdown is visible, keeping the banner slightly above center for better composition
- further enlarge the countdown label and stroke so the start timer stands out before the match begins

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d93c4ac8548333bdd500643c9a9b96