### PR TITLE
Ensure level-up UI resets movement input

### DIFF
--- a/src/client/Controllers/InputController.lua
+++ b/src/client/Controllers/InputController.lua
@@ -61,6 +61,19 @@ function InputController:KnitStart()
     end)
 end
 
+function InputController:ResetMovementState()
+    self.ActiveMoveKeys = {}
+    self.MoveVector = Vector3.zero
+    self.LastMoveVector = Vector3.zero
+
+    local player = Players.LocalPlayer
+    local character = player and player.Character
+    local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+    if humanoid then
+        humanoid:Move(Vector3.zero, true)
+    end
+end
+
 function InputController:BindMovement()
     local function updateMoveVector()
         local move = Vector3.zero

--- a/src/client/PlayerProgress.client.lua
+++ b/src/client/PlayerProgress.client.lua
@@ -45,6 +45,12 @@ local function waitForController(name: string)
     end
 end
 
+local inputController: any = nil
+
+task.spawn(function()
+    inputController = waitForController("InputController")
+end)
+
 local function computeXPToNext(level: number): number
     if level >= MAX_LEVEL then
         return 0
@@ -347,7 +353,19 @@ local function applyLevel(level: number, xp: number, xpToNext: number)
     setTargetFromXP(xp, xpToNext)
 end
 
+local function resetMovementState()
+    if not inputController then
+        inputController = waitForController("InputController")
+    end
+
+    if inputController and typeof(inputController.ResetMovementState) == "function" then
+        inputController:ResetMovementState()
+    end
+end
+
 local function setInputBlocked(enabled: boolean)
+    resetMovementState()
+
     if enabled and not freezeBlockBound then
         local function sink()
             return Enum.ContextActionResult.Sink


### PR DESCRIPTION
## Summary
- add a public `ResetMovementState` helper to `InputController` to clear movement vectors and halt the humanoid
- cache the `InputController` in the player progress script and reset movement whenever level-up input blocking toggles

## Testing
- not run (Roblox Studio not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e243158d248333bc71fa8cde785f10