### PR TITLE
Ensure thawed enemies resume running after world freeze

### DIFF
--- a/src/server/Services/EnemyService.lua
+++ b/src/server/Services/EnemyService.lua
@@ -185,6 +185,7 @@ function EnemyService:_setEnemyFrozen(enemyData, enabled: boolean)
                         humanoid.JumpHeight = record.JumpValue
                     end
                     humanoid.AutoRotate = record.AutoRotate
+                    humanoid:ChangeState(Enum.HumanoidStateType.Running)
                 end
                 self.FrozenEnemyHumanoids[humanoid] = nil
             end
@@ -226,6 +227,7 @@ function EnemyService:SetWorldFreeze(enabled: boolean)
                     humanoid.JumpHeight = record.JumpValue
                 end
                 humanoid.AutoRotate = record.AutoRotate
+                humanoid:ChangeState(Enum.HumanoidStateType.Running)
             end
             self.FrozenEnemyHumanoids[humanoid] = nil
         end


### PR DESCRIPTION
## Summary
- change enemy thaw logic to restore humanoids to the Running state when unfreezing individuals
- ensure world freeze removal also pushes restored humanoids back into the Running state

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e24d11bcac833395dffaf2b1834e08