### PR TITLE
Spawn enemies near players and remove spawn restrictions

### DIFF
--- a/src/shared/Config.lua
+++ b/src/shared/Config.lua
@@ -31,9 +31,9 @@ Config.Enemy = {
     BossPhaseMaxActive = 60,
     PathRefresh = 0.25,
     Spawn = {
-        MinSpawnDistance = 40,
-        PortalCooldown = 1.0,
-        Separation = 6,
+        PlayerRadiusMin = 10,
+        PlayerRadiusMax = 15,
+        SpawnHeight = 6,
         MaxSpawnAttempts = 8,
     },
 }


### PR DESCRIPTION
## Summary
- spawn enemies around alive players instead of fixed portals and simplify spawn selection
- remove spawn cancellation logic so attempts always create enemies when a player anchor is available
- update enemy spawn configuration for player radius and spawn height options

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e24f2a318c833384d9f54400f75ce4