### PR TITLE
Share party XP rewards, show party selection counts, and enlarge status text

### DIFF
--- a/src/server/Services/EnemyService.lua
+++ b/src/server/Services/EnemyService.lua
@@ -895,7 +895,7 @@ function EnemyService:OnEnemyDied(enemyData)
         local leveling = Config.Leveling
         local xpConfig = leveling and leveling.XP
         local killXP = xpConfig and xpConfig.Kill or Config.Rewards.KillXP
-        self.RewardService:AddXP(killer, Config.Rewards.KillXP, killXP, "Kill")
+        self.RewardService:AddPartyXP(Config.Rewards.KillXP, killXP, "Kill")
     end
 
     model:Destroy()

--- a/src/server/Services/PlayerProgressService.lua
+++ b/src/server/Services/PlayerProgressService.lua
@@ -482,6 +482,7 @@ function PlayerProgressService:BroadcastLevelUpStatus()
     local committed = 0
     local minRemaining = nil
     local now = time()
+    local playerCount = #Players:GetPlayers()
 
     for _, profile in pairs(self.Profiles) do
         local active = profile and profile.activeLevelUp
@@ -502,6 +503,7 @@ function PlayerProgressService:BroadcastLevelUpStatus()
         Total = total,
         Committed = committed,
         Remaining = minRemaining,
+        PlayerCount = playerCount,
     })
 end
 

--- a/src/server/Services/RewardService.lua
+++ b/src/server/Services/RewardService.lua
@@ -96,7 +96,7 @@ function RewardService:AddGold(player: Player, amount: number)
     self:PushStats(player)
 end
 
-function RewardService:AddXP(player: Player, amount: number, progressAmount: number?, reason: string?)
+function RewardService:_grantXP(player: Player, amount: number, progressAmount: number?, reason: string?)
     local stats = self.PlayerStats[player]
     if not stats then
         return
@@ -129,6 +129,21 @@ function RewardService:AddXP(player: Player, amount: number, progressAmount: num
     end
     if progressService and progressXP > 0 then
         progressService:AddXP(player, progressXP, reason)
+    end
+end
+
+function RewardService:AddXP(player: Player, amount: number, progressAmount: number?, reason: string?)
+    self:_grantXP(player, amount, progressAmount, reason)
+end
+
+function RewardService:AddPartyXP(amount: number, progressAmount: number?, reason: string?)
+    local delta = math.floor(amount or 0)
+    if delta <= 0 then
+        return
+    end
+
+    for player in pairs(self.PlayerStats) do
+        self:_grantXP(player, delta, progressAmount, reason)
     end
 end
 
@@ -187,8 +202,9 @@ function RewardService:GrantMilestoneRewards(threshold: number)
 end
 
 function RewardService:FinalizeMatch(reason: string)
+    self:AddPartyXP(Config.Rewards.ResultXPBonus, Config.Rewards.ResultXPBonus, "Result")
+
     for player, stats in pairs(self.PlayerStats) do
-        self:AddXP(player, Config.Rewards.ResultXPBonus, Config.Rewards.ResultXPBonus, "Result")
         self.ResultReasons[player] = reason
         if self.DataStore then
             pcall(function()


### PR DESCRIPTION
## Summary
- add a shared XP grant helper and party-wide reward method so kills and match bonuses reward the whole group
- include total player counts when broadcasting level-up status to support party progress awareness
- update the client modal to show committed selections against the party size with optional countdown text
- enlarge the level-up status label and create a fallback instance so countdowns and party ratios stay readable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2544e5a608333a05f4b469125e768